### PR TITLE
docs: handoff prep — CLAUDE.md, STATUS.md, multi-organism + v1 decisions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,82 @@
+# CLAUDE.md — OQAE working guide for AI sessions
+
+> Read this first every session. It is the orientation for daily, mostly-autonomous
+> work on OQAE. For *what* to build next, read `docs/STATUS.md` (live state) and
+> `docs/PROJECT_PLAN.md` (roadmap + design decisions).
+
+## What this project is
+
+**OQAE (Omics Quantized Auto Encoder)** learns a **discrete, universal latent
+space for single-cell omics** with a residual VQ-VAE. Each scRNA-seq cell is
+encoded as a set of discrete codes (codebook indices); the generative decoder
+turns codes back into expression. We start with scRNA-seq because the CZ
+CELLxGENE Census provides it at scale.
+
+The Python package is `omvqvae` (under `src/omvqvae/`); the distribution name is
+`oqae`.
+
+## Non-negotiable design decisions (don't re-litigate — see the decisions log in PROJECT_PLAN.md)
+
+- **Data**: stream from the CZ CELLxGENE Census via TileDB-SOMA
+  (`cellxgene_census` + `tiledbsoma` + `tiledbsoma_ml`); also support local
+  `.h5ad` / `.zarr` AnnData. Not Zarr/Dask-primary.
+- **Input**: ingest **raw counts**; reconstruct with **NB / ZINB**; library size
+  handled internally (scVI-style). Log-normalized/Gaussian is a pluggable
+  alternative only.
+- **Organisms**: support **human + mouse**, organism-aware with a per-organism
+  gene space; **one model per organism** in v1.
+- **v1 model is unconditional** (no batch/covariate input); revisit only if
+  benchmarking shows batch effects hurt the latent space.
+- **Monitoring = Weights & Biases** (offline-friendly). No bespoke system monitor.
+
+## Where things live
+
+- `docs/PROJECT_PLAN.md` — roadmap (PRs #1–#10), architecture, decisions log.
+- `docs/STATUS.md` — current state, what was done last, the next concrete task.
+  **Update this at the end of every working session.**
+- `src/omvqvae/` — the package. Target structure is in PROJECT_PLAN.md; create
+  modules as their PR lands (`data/`, `layers/`, `models/`, `train/`,
+  `inference/`, `utils/`).
+- `tests/` — pytest; mirror the package; keep tests fast and **offline by
+  default** (mark live-Census/network tests as skippable).
+
+## Development workflow (uv-based)
+
+```bash
+make setup-env        # uv sync --all-extras  (creates .venv)
+make format           # autopep8 + black + isort (auto-fix)
+make ci               # format-check + flake8 + mypy + pytest  ← must pass before committing
+```
+
+Individual gates: `make lint`, `make type-check` (mypy strict on `src/omvqvae`),
+`make test` (pytest with coverage). CI runs the same checks on Python 3.11 and
+3.12, plus a bandit/safety security job.
+
+## Conventions
+
+- **Strict typing**: mypy is enabled and CI-enforced. Fully annotate public APIs.
+- **Docstrings**: NumPy style for public functions/classes.
+- **Formatting**: black + isort (line length 88); flake8 clean.
+- **Tests**: add tests with every code change; keep coverage high; default to
+  tiny synthetic fixtures so the suite runs offline and fast.
+- **Dependencies**: add a new dep only in the PR that first uses it, and refresh
+  `uv.lock` (`uv lock`) in the same change.
+
+## Git / PR workflow
+
+- Each automated run works on a fresh branch off the latest `main`
+  (e.g. `claude/<topic>`), scoped to roughly **one roadmap PR** (or one coherent
+  sub-task) — don't sprawl across multiple PRs in a single run.
+- Run `make ci` green, commit with a clear message, push, and **open a PR**.
+- Leave merging to a human reviewer unless explicitly told otherwise.
+- Co-author trailer on commits:
+  `Co-Authored-By: Claude <noreply@anthropic.com>`.
+
+## When to stop and ask vs. proceed
+
+- **Proceed** on well-scoped, decided work (the next task in `docs/STATUS.md`,
+  bug fixes, tests, docs).
+- **Ask first** (via a notification / leave it for the human) when a choice is
+  architecturally significant, contradicts a decision above, requires a new
+  heavy dependency not already planned, or is ambiguous. Capture the open
+  question in `docs/STATUS.md` so the next session sees it.

--- a/README.md
+++ b/README.md
@@ -197,7 +197,9 @@ make pr
 
 ## 📚 Documentation
 
-- [docs/PROJECT_PLAN.md](docs/PROJECT_PLAN.md) - Complete project roadmap and architecture
+- [docs/PROJECT_PLAN.md](docs/PROJECT_PLAN.md) - Complete project roadmap, architecture, and design-decisions log
+- [docs/STATUS.md](docs/STATUS.md) - Live status and the current next task
+- [CLAUDE.md](CLAUDE.md) - Orientation guide for AI/contributor sessions
 - [docs/DEVELOPMENT_WORKFLOW.md](docs/DEVELOPMENT_WORKFLOW.md) - Development guidelines
 - [docs/WORKFLOW_MONITORING.md](docs/WORKFLOW_MONITORING.md) - CI/CD monitoring
 

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -62,9 +62,28 @@ sources:
 
 Both sources are normalized to a common minibatch contract:
 `(counts, obs_covariates)` where `counts` is a dense/sparse cell × gene tensor
-of **raw counts** and `obs_covariates` carries optional conditioning fields
-(e.g. batch/dataset id). A shared **gene-space mapping** aligns each source to
-the model's expected feature ordering.
+of **raw counts** and `obs_covariates` carries optional metadata fields
+(e.g. batch/dataset id, organism). A per-organism **gene-space mapping** aligns
+each source to the model's expected feature ordering (see below).
+
+#### **Multi-organism support (human + mouse)**
+
+The Census hosts multiple organisms; **v1 supports both human and mouse**. Each
+organism has its own gene/feature universe, so OQAE is **organism-aware**:
+
+- `organism` is an explicit parameter of the data layer (and is recorded in
+  model metadata). Census slices are queried per-organism (the Census exposes
+  `homo_sapiens` and `mus_musculus` experiments separately).
+- Each organism has its own **reference gene set** (the Census `var` index for
+  that organism, optionally restricted to a configurable panel). Local AnnData
+  is aligned/subset to the reference for its organism — genes present in the
+  reference but missing locally are zero-filled; extra local genes are dropped —
+  with a warning when overlap is low.
+- A trained model carries a fixed organism + gene vocabulary; **v1 trains one
+  model per organism** (separate codebooks/feature spaces). Cross-organism
+  unification into a single shared latent space is an explicit **open design
+  question deferred past v1** (would require ortholog mapping or a shared gene
+  embedding); it does not block the v1 data layer or model.
 
 ### **Data Flow Architecture**
 ```
@@ -120,10 +139,14 @@ Concretely:
 - **Straight-through estimator** for gradient flow through the discrete
   bottleneck; **codebook/commitment losses** and **perplexity** monitoring to
   track codebook utilization and guard against collapse.
-- **Generative decoder**: maps quantized codes (optionally + size factor +
-  covariates) to NB/ZINB parameters over genes.
-- **Covariate conditioning**: optional categorical conditioning (e.g.
-  batch/dataset id) to encourage a shared latent space across studies.
+- **Generative decoder**: maps quantized codes (+ size factor) to NB/ZINB
+  parameters over genes.
+- **Conditioning**: **v1 is unconditional** (no batch/dataset covariate fed to
+  the model). Optional categorical conditioning to encourage cross-study
+  integration is deferred; we will first **benchmark whether batch effects are
+  actually a problem** in the discrete latent space (PR #9) and only add
+  conditioning if needed. The data layer still *carries* covariates in the
+  minibatch so this can be enabled later without a data-format change.
 - **CPU/GPU**: inference on CPU, training optimized for GPU.
 
 ### **Experiment Tracking & Monitoring**
@@ -195,19 +218,27 @@ src/omvqvae/
   (black/isort/flake8/**mypy**/pytest/bandit), pre-commit, Makefile.
 - Exit criteria: green CI, package imports a logger, strict mypy passes.
 
-#### **PR #2: Data Layer — Census streaming + local AnnData**
-- **Scope**: unified data interface over two sources.
+#### **PR #2: Data Layer — Census streaming + local AnnData (NEXT)**
+- **Scope**: unified data interface over two sources, **organism-aware
+  (human + mouse)**.
 - **Files**: `data/census.py`, `data/anndata_io.py`, `data/dataset.py`,
   `data/normalize.py`.
 - **Key features**:
   - CELLxGENE Census streaming via `cellxgene_census` + `tiledbsoma` +
-    `tiledbsoma_ml` (pinned Census version, `obs_query` filtering, raw layer).
+    `tiledbsoma_ml` (pinned Census version, `obs_query` filtering, raw layer),
+    with `organism` selecting the `homo_sapiens` / `mus_musculus` experiment.
   - Local `.h5ad` / `.zarr` loaders with chunked/backed reads.
-  - Common `(raw_counts, covariates)` minibatch contract + gene-space
-    alignment.
+  - **Per-organism reference gene set** + alignment helper that maps any source
+    (Census or local) onto that organism's feature ordering (zero-fill missing,
+    drop extra, warn on low overlap).
+  - Common `(raw_counts, covariates)` minibatch contract (covariates carry
+    organism + batch/dataset id even though v1 is unconditional).
   - Size-factor computation; internal-normalization helpers.
-- **Exit criteria**: stream a small Census slice and iterate a local AnnData
-  through the *same* DataLoader API; tests with a tiny fixture; bounded memory.
+- **Dependencies to add** (with refreshed `uv.lock`): `cellxgene-census`,
+  `tiledbsoma`, `tiledbsoma-ml`.
+- **Exit criteria**: stream a small Census slice (human *and* mouse) and iterate
+  a local AnnData through the *same* DataLoader API; tests with a tiny offline
+  fixture (live-Census tests marked/skippable); strict mypy + bounded memory.
 
 #### **PR #3: Residual Vector Quantizer Layer**
 - **Scope**: configurable residual VQ with straight-through estimator.
@@ -320,6 +351,20 @@ dependencies = [
   collapse); faithful encode→decode reconstruction; meaningful structure in the
   discrete space.
 
+## 🧭 **Design Decisions Log**
+
+A running record of decisions so future sessions don't re-litigate them.
+
+| Date | Decision | Rationale |
+|------|----------|-----------|
+| 2026-06-17 | **Goal**: discrete, universal latent space for omics — cells → sets of discrete codes that plug into a generative decoder. Start with scRNA-seq. | Codes are composable/decoder-pluggable; enables compression, integration, and generation from a shared vocabulary. |
+| 2026-06-17 | **Primary data = stream from CZ CELLxGENE Census** (TileDB-SOMA); also support local `.h5ad`/`.zarr`. Dropped Zarr/Dask-primary framing. | Census hosts a huge standardized scRNA-seq corpus; streaming avoids downloading it. |
+| 2026-06-17 | **Ingest raw counts; reconstruct with NB/ZINB**, library size handled internally. Log-normalized/Gaussian kept as pluggable alternative. | Matches scVI-family practice; preserves count statistics; avoids baking in normalization. |
+| 2026-06-17 | **Monitoring = Weights & Biases** (offline-friendly); removed bespoke `system_monitor`. | Standard tool; less code to maintain. |
+| 2026-06-17 | **Multi-organism: support human + mouse**, organism-aware with a per-organism gene space; **one model per organism in v1**. Cross-organism unification deferred. | Each organism has a distinct gene universe; ortholog/shared-embedding mapping is a separate research question. |
+| 2026-06-17 | **v1 model is unconditional** (no batch/covariate input). Revisit only if benchmarking shows batch effects hurt the latent space. | Keep v1 simple; data layer still carries covariates so conditioning can be added later without a format change. |
+| 2026-06-17 | **Next implementation = PR #2 (data layer).** | Unblocks the quantizer and model PRs. |
+
 ## 🔄 **Future Roadmap (Post-v1.0)**
 - **Other omics modalities**: extend the discrete-codebook approach beyond
   scRNA-seq (ATAC, protein, multi-omics joint training).
@@ -335,6 +380,7 @@ dependencies = [
 
 ---
 
-**Last Updated**: 2026-06-17 — pivot to CELLxGENE Census streaming, raw-count
-(NB/ZINB) modeling, discrete universal latent space, and W&B-based monitoring.
+**Last Updated**: 2026-06-17 — clarified multi-organism (human + mouse) support,
+v1-unconditional decision, and added the design-decisions log.
+**Current Focus**: PR #2 — organism-aware data layer (see `docs/STATUS.md`).
 **Next Review**: After PR #2 (data layer).

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,0 +1,59 @@
+# OQAE — Live Status & Handoff
+
+> Single source of truth for "where are we and what's next." **Update this at the
+> end of every working session** so the next session can pick up cold. Keep it
+> short; deep rationale lives in `docs/PROJECT_PLAN.md`.
+
+**Last updated:** 2026-06-17
+
+## Current state
+
+- **PR #1 (Foundation) — DONE and merged to `main`.**
+  - Logging (`src/omvqvae/utils/logging.py`), uv dev workflow, CI/CD
+    (black/isort/flake8/**mypy strict**/pytest, bandit/safety), pre-commit.
+  - Template leftovers and the old `system_monitor` utility have been removed.
+  - `pyproject.toml` core deps trimmed; `wandb` kept for tracking.
+  - `make ci` is green; pytest at 100% coverage on the current (small) codebase.
+- Plan/docs reflect the pivot: Census streaming, raw-count NB/ZINB modeling,
+  discrete universal latent space, human+mouse, v1 unconditional, W&B monitoring.
+
+## Next task — PR #2: organism-aware data layer
+
+Implement the unified data interface (see PROJECT_PLAN.md → "PR #2" for full
+scope and exit criteria). In short:
+
+1. Add deps and refresh the lockfile: `cellxgene-census`, `tiledbsoma`,
+   `tiledbsoma-ml` (`uv lock`).
+2. `data/census.py` — stream raw counts from the Census via
+   `cellxgene_census` + `tiledbsoma` + `tiledbsoma_ml`
+   (`ExperimentDataset` + `experiment_dataloader()`), with `organism`
+   selecting `homo_sapiens` / `mus_musculus`, `obs_query` filtering, raw layer.
+3. `data/anndata_io.py` — load local `.h5ad` / `.zarr` (chunked/backed).
+4. `data/dataset.py` — per-organism reference gene set + alignment
+   (zero-fill missing genes, drop extras, warn on low overlap); common
+   `(raw_counts, covariates)` minibatch contract (covariates carry organism +
+   batch/dataset id, unused by v1 model).
+5. `data/normalize.py` — size factors + internal-normalization helpers.
+6. Tests: tiny **offline** synthetic fixtures; mark live-Census tests skippable.
+   Keep `make ci` green (strict mypy, coverage).
+
+**Definition of done:** iterate a local AnnData and a small Census slice (human
+*and* mouse) through the *same* DataLoader API; CI green; PR opened.
+
+## Open questions / parked
+
+- **Cross-organism unification** (single shared latent across human+mouse):
+  deferred past v1; needs ortholog mapping or shared gene embedding.
+- **NB vs ZINB vs log-normalized+Gaussian** for the quantized setting: support
+  both; benchmark in PR #9.
+- **Batch-effect conditioning**: v1 unconditional; benchmark whether it's needed
+  (PR #9) before adding.
+- **Census version pin**: latest stable is `2025-01-30`; confirm the newest
+  stable at implementation time and pin it.
+
+## Changelog (most recent first)
+
+- **2026-06-17** — PR #5 merged: project pivot (Census streaming, raw-count
+  NB/ZINB, discrete latent), cleanup (removed template/system_monitor code),
+  strict mypy re-enabled. Added CLAUDE.md + this STATUS.md; clarified
+  multi-organism support and v1-unconditional decision.


### PR DESCRIPTION
## Description

Prepares durable, cross-session handoff state so a fresh session can pick up **PR #2 (the data layer)** cold tomorrow. Docs only — no code or CI changes.

## Changes

- **Add `CLAUDE.md`** — per-session orientation: project summary, the non-negotiable design decisions, dev workflow (`make ci`), conventions, git/PR practice, and when to ask vs. proceed.
- **Add `docs/STATUS.md`** — live status + the concrete next task (PR #2), open questions, and a changelog. Intended to be updated at the end of every session.
- **`docs/PROJECT_PLAN.md`** — incorporate the latest decisions:
  - Multi-organism support (**human + mouse**), organism-aware with a per-organism gene space; **one model per organism** in v1 (cross-organism unification deferred).
  - **v1 model is unconditional** (data layer still carries covariates so conditioning can be added later without a format change); benchmark batch effects before adding.
  - New **Design Decisions Log**; expanded PR #2 scope + exit criteria.
- **`README.md`** — link the new `STATUS.md` and `CLAUDE.md`.

## Notes

These docs need to be on `main` for tomorrow's fresh session to read them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LDtt9H1jfWpjDym4Hx1gsi)_