### PR TITLE
feat(data): organism-aware local data layer (PR #2, slice 1)

### DIFF
--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -368,7 +368,8 @@ A running record of decisions so future sessions don't re-litigate them.
 | 2026-06-17 | **v1 model is unconditional** (no batch/covariate input). Revisit only if benchmarking shows batch effects hurt the latent space. | Keep v1 simple; data layer still carries covariates so conditioning can be added later without a format change. |
 | 2026-06-17 | **Next implementation = PR #2 (data layer).** | Unblocks the quantizer and model PRs. |
 | 2026-06-18 | **Split PR #2 into two slices**: (1) local AnnData + organism-aware gene alignment + normalization + shared `Minibatch` contract (offline-testable, no heavy deps); (2) Census streaming (TileDB-SOMA deps + network-gated test). Slice 1 landed first. | Keeps each PR focused and fully CI-verifiable offline; the Census path needs heavy deps and a live network it can't exercise in CI, so it slots into the contract slice 1 establishes. |
-| 2026-06-18 | **Pin `zarr>=2.12.0,<3`.** | `anndata` (0.11.x) does not yet support zarr-python v3; an unconstrained `zarr>=2.12.0` resolved to 3.x and broke `import anndata`. |
+| 2026-06-18 | ~~**Pin `zarr>=2.12.0,<3`.**~~ Superseded same day (see next row). | `anndata` (0.11.x) did not support zarr-python v3; an unconstrained `zarr>=2.12.0` resolved to 3.x and broke `import anndata`. |
+| 2026-06-18 | **Require `zarr>=3.0.0` + `anndata>=0.12.0`** (reverses the `zarr<3` pin above). | `anndata` 0.12 adds zarr-python v3 support; standardize on zarr v3 rather than holding back on the v2 line. |
 | 2026-06-18 | **Minibatch contract = `Minibatch(counts, size_factors, covariates)`** as a dataclass; per-cell samples are dicts (`counts`, `size_factor`, `organism`, `batch`) stacked by `collate_minibatch`. Covariates always carry `organism` + `batch`. | One contract shared by every source (local now, Census next); v1 ignores covariates but they travel with the batch so conditioning can be added without a format change. |
 
 ## 🔄 **Future Roadmap (Post-v1.0)**

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -218,7 +218,10 @@ src/omvqvae/
   (black/isort/flake8/**mypy**/pytest/bandit), pre-commit, Makefile.
 - Exit criteria: green CI, package imports a logger, strict mypy passes.
 
-#### **PR #2: Data Layer — Census streaming + local AnnData (NEXT)**
+#### **PR #2: Data Layer — Census streaming + local AnnData (IN PROGRESS)**
+- **Status**: split into two slices. *Slice 1 (local AnnData + organism-aware
+  gene alignment + normalization + shared `Minibatch` contract) is DONE.* Slice 2
+  (Census streaming via TileDB-SOMA, network-gated test) is next.
 - **Scope**: unified data interface over two sources, **organism-aware
   (human + mouse)**.
 - **Files**: `data/census.py`, `data/anndata_io.py`, `data/dataset.py`,
@@ -364,6 +367,9 @@ A running record of decisions so future sessions don't re-litigate them.
 | 2026-06-17 | **Multi-organism: support human + mouse**, organism-aware with a per-organism gene space; **one model per organism in v1**. Cross-organism unification deferred. | Each organism has a distinct gene universe; ortholog/shared-embedding mapping is a separate research question. |
 | 2026-06-17 | **v1 model is unconditional** (no batch/covariate input). Revisit only if benchmarking shows batch effects hurt the latent space. | Keep v1 simple; data layer still carries covariates so conditioning can be added later without a format change. |
 | 2026-06-17 | **Next implementation = PR #2 (data layer).** | Unblocks the quantizer and model PRs. |
+| 2026-06-18 | **Split PR #2 into two slices**: (1) local AnnData + organism-aware gene alignment + normalization + shared `Minibatch` contract (offline-testable, no heavy deps); (2) Census streaming (TileDB-SOMA deps + network-gated test). Slice 1 landed first. | Keeps each PR focused and fully CI-verifiable offline; the Census path needs heavy deps and a live network it can't exercise in CI, so it slots into the contract slice 1 establishes. |
+| 2026-06-18 | **Pin `zarr>=2.12.0,<3`.** | `anndata` (0.11.x) does not yet support zarr-python v3; an unconstrained `zarr>=2.12.0` resolved to 3.x and broke `import anndata`. |
+| 2026-06-18 | **Minibatch contract = `Minibatch(counts, size_factors, covariates)`** as a dataclass; per-cell samples are dicts (`counts`, `size_factor`, `organism`, `batch`) stacked by `collate_minibatch`. Covariates always carry `organism` + `batch`. | One contract shared by every source (local now, Census next); v1 ignores covariates but they travel with the batch so conditioning can be added without a format change. |
 
 ## 🔄 **Future Roadmap (Post-v1.0)**
 - **Other omics modalities**: extend the discrete-codebook approach beyond

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -4,7 +4,7 @@
 > end of every working session** so the next session can pick up cold. Keep it
 > short; deep rationale lives in `docs/PROJECT_PLAN.md`.
 
-**Last updated:** 2026-06-17
+**Last updated:** 2026-06-18
 
 ## Current state
 
@@ -14,31 +14,47 @@
   - Template leftovers and the old `system_monitor` utility have been removed.
   - `pyproject.toml` core deps trimmed; `wandb` kept for tracking.
   - `make ci` is green; pytest at 100% coverage on the current (small) codebase.
+- **PR #2 (data layer) — slice 1 of 2 DONE (this PR), Census slice next.**
+  - `data/normalize.py` — size factors + internal log1p/depth normalization.
+  - `data/dataset.py` — organism-aware `GeneVocabulary`, `align_to_reference`
+    (zero-fill missing / drop extra / warn on low overlap), the shared
+    `Minibatch` `(counts, size_factors, covariates)` contract, `CountsDataset`,
+    `collate_minibatch`.
+  - `data/anndata_io.py` — local `.h5ad` / `.zarr` loaders +
+    `build_anndata_dataloader` producing the shared `Minibatch` contract.
+  - Human *and* mouse AnnData iterate through the *same* DataLoader API.
+  - Pinned `zarr>=2.12.0,<3` (anndata does not support zarr-python v3) and
+    refreshed `uv.lock`. Tests are 100%-covered and fully offline. `make ci`
+    green.
 - Plan/docs reflect the pivot: Census streaming, raw-count NB/ZINB modeling,
   discrete universal latent space, human+mouse, v1 unconditional, W&B monitoring.
 
-## Next task — PR #2: organism-aware data layer
+## Next task — PR #2 slice 2: Census streaming
 
-Implement the unified data interface (see PROJECT_PLAN.md → "PR #2" for full
-scope and exit criteria). In short:
+Finish the data layer by adding the CELLxGENE Census source behind the *same*
+`Minibatch` contract already established in slice 1.
 
 1. Add deps and refresh the lockfile: `cellxgene-census`, `tiledbsoma`,
-   `tiledbsoma-ml` (`uv lock`).
+   `tiledbsoma-ml` (`uv lock`). Confirm the newest stable Census version and pin
+   it (latest known stable was `2025-01-30`).
 2. `data/census.py` — stream raw counts from the Census via
    `cellxgene_census` + `tiledbsoma` + `tiledbsoma_ml`
    (`ExperimentDataset` + `experiment_dataloader()`), with `organism`
    selecting `homo_sapiens` / `mus_musculus`, `obs_query` filtering, raw layer.
-3. `data/anndata_io.py` — load local `.h5ad` / `.zarr` (chunked/backed).
-4. `data/dataset.py` — per-organism reference gene set + alignment
-   (zero-fill missing genes, drop extras, warn on low overlap); common
-   `(raw_counts, covariates)` minibatch contract (covariates carry organism +
-   batch/dataset id, unused by v1 model).
-5. `data/normalize.py` — size factors + internal-normalization helpers.
-6. Tests: tiny **offline** synthetic fixtures; mark live-Census tests skippable.
-   Keep `make ci` green (strict mypy, coverage).
+   Reuse `GeneVocabulary` / `align_to_reference` and emit `Minibatch` (build the
+   per-organism reference gene set from the Census `var` index).
+3. Tests: tiny **offline** synthetic fixtures for the alignment/contract glue;
+   mark the live-Census streaming test skippable (network-gated). Keep `make ci`
+   green (strict mypy, coverage).
 
-**Definition of done:** iterate a local AnnData and a small Census slice (human
-*and* mouse) through the *same* DataLoader API; CI green; PR opened.
+**Definition of done:** stream a small Census slice (human *and* mouse) through
+the same `build_*` DataLoader API as local AnnData; live test marked skippable;
+CI green; PR opened.
+
+> Note: this run deliberately split PR #2. Slice 1 (local AnnData + alignment +
+> normalization + contract) is fully offline-testable and lands here; slice 2
+> (Census streaming) carries the heavy TileDB-SOMA deps and a network-gated test
+> and is the next chunk — see PROJECT_PLAN.md decisions log.
 
 ## Open questions / parked
 
@@ -53,6 +69,14 @@ scope and exit criteria). In short:
 
 ## Changelog (most recent first)
 
+- **2026-06-18** — PR #2 slice 1: organism-aware **local** data layer. Added
+  `data/normalize.py` (size factors + internal log1p/depth normalization),
+  `data/dataset.py` (`GeneVocabulary`, `align_to_reference`, `Minibatch`,
+  `CountsDataset`, `collate_minibatch`), `data/anndata_io.py`
+  (`.h5ad`/`.zarr` loaders + `build_anndata_dataloader`). Human *and* mouse
+  iterate the same DataLoader API. Pinned `zarr<3` and refreshed `uv.lock`.
+  100% coverage, fully offline, `make ci` green. Census streaming deferred to
+  slice 2.
 - **2026-06-17** — PR #5 merged: project pivot (Census streaming, raw-count
   NB/ZINB, discrete latent), cleanup (removed template/system_monitor code),
   strict mypy re-enabled. Added CLAUDE.md + this STATUS.md; clarified

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -23,8 +23,8 @@
   - `data/anndata_io.py` — local `.h5ad` / `.zarr` loaders +
     `build_anndata_dataloader` producing the shared `Minibatch` contract.
   - Human *and* mouse AnnData iterate through the *same* DataLoader API.
-  - Pinned `zarr>=2.12.0,<3` (anndata does not support zarr-python v3) and
-    refreshed `uv.lock`. Tests are 100%-covered and fully offline. `make ci`
+  - Requires `zarr>=3.0.0` + `anndata>=0.12.0` (zarr-python v3 support);
+    `uv.lock` refreshed. Tests are 100%-covered and fully offline. `make ci`
     green.
 - Plan/docs reflect the pivot: Census streaming, raw-count NB/ZINB modeling,
   discrete universal latent space, human+mouse, v1 unconditional, W&B monitoring.
@@ -74,9 +74,9 @@ CI green; PR opened.
   `data/dataset.py` (`GeneVocabulary`, `align_to_reference`, `Minibatch`,
   `CountsDataset`, `collate_minibatch`), `data/anndata_io.py`
   (`.h5ad`/`.zarr` loaders + `build_anndata_dataloader`). Human *and* mouse
-  iterate the same DataLoader API. Pinned `zarr<3` and refreshed `uv.lock`.
-  100% coverage, fully offline, `make ci` green. Census streaming deferred to
-  slice 2.
+  iterate the same DataLoader API. Standardized on `zarr>=3` + `anndata>=0.12`
+  and refreshed `uv.lock`. 100% coverage, fully offline, `make ci` green.
+  Census streaming deferred to slice 2.
 - **2026-06-17** — PR #5 merged: project pivot (Census streaming, raw-count
   NB/ZINB, discrete latent), cleanup (removed template/system_monitor code),
   strict mypy re-enabled. Added CLAUDE.md + this STATUS.md; clarified

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ requires-python = ">=3.11"
 dependencies = [
     "torch>=2.0.0",
     "anndata>=0.8.0",
-    "zarr>=2.12.0",
+    "zarr>=2.12.0,<3",  # anndata does not yet support zarr-python v3
     "dask[array]>=2023.1.0",
     "numpy>=1.21.0",
     "pandas>=1.5.0",
@@ -99,6 +99,11 @@ warn_unused_ignores = true
 warn_no_return = true
 warn_unreachable = true
 strict_equality = true
+
+[[tool.mypy.overrides]]
+# Third-party libraries without bundled type stubs.
+module = ["anndata.*", "scipy.*"]
+ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,8 @@ classifiers = [
 requires-python = ">=3.11"
 dependencies = [
     "torch>=2.0.0",
-    "anndata>=0.8.0",
-    "zarr>=2.12.0,<3",  # anndata does not yet support zarr-python v3
+    "anndata>=0.12.0",  # zarr-python v3 support
+    "zarr>=3.0.0",
     "dask[array]>=2023.1.0",
     "numpy>=1.21.0",
     "pandas>=1.5.0",

--- a/src/omvqvae/data/__init__.py
+++ b/src/omvqvae/data/__init__.py
@@ -1,1 +1,45 @@
-"""Data I/O and preprocessing modules for OQAE."""
+"""
+Data layer for OQAE.
+
+Organism-aware loading of raw single-cell counts onto a shared minibatch
+contract. This slice covers local AnnData (``.h5ad`` / ``.zarr``) plus the
+gene-space alignment, normalization, and minibatch primitives; CELLxGENE Census
+streaming lands next, reusing the same :class:`Minibatch` contract.
+"""
+
+from omvqvae.data.anndata_io import (
+    build_anndata_dataloader,
+    extract_counts,
+    load_anndata,
+)
+from omvqvae.data.dataset import (
+    SUPPORTED_ORGANISMS,
+    CountsDataset,
+    GeneVocabulary,
+    Minibatch,
+    align_to_reference,
+    collate_minibatch,
+)
+from omvqvae.data.normalize import (
+    compute_size_factors,
+    normalize_counts,
+    to_dense,
+)
+
+__all__ = [
+    # vocabulary / alignment / contract
+    "SUPPORTED_ORGANISMS",
+    "GeneVocabulary",
+    "align_to_reference",
+    "Minibatch",
+    "CountsDataset",
+    "collate_minibatch",
+    # normalization
+    "compute_size_factors",
+    "normalize_counts",
+    "to_dense",
+    # local AnnData
+    "load_anndata",
+    "extract_counts",
+    "build_anndata_dataloader",
+]

--- a/src/omvqvae/data/anndata_io.py
+++ b/src/omvqvae/data/anndata_io.py
@@ -1,0 +1,193 @@
+"""
+Local AnnData (``.h5ad`` / ``.zarr``) loaders for OQAE.
+
+This module bridges on-disk AnnData files to OQAE's shared minibatch contract:
+it reads raw counts, aligns them to an organism's :class:`GeneVocabulary`, and
+builds a :class:`torch.utils.data.DataLoader` that yields :class:`Minibatch`
+batches — the *same* API the Census streaming loader will expose.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, List, Optional, Tuple, Union
+
+from torch.utils.data import DataLoader
+
+from omvqvae.data.dataset import (
+    CountsDataset,
+    GeneVocabulary,
+    align_to_reference,
+    collate_minibatch,
+)
+from omvqvae.data.normalize import CountMatrix
+from omvqvae.utils.logging import get_logger
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from anndata import AnnData
+
+logger = get_logger(__name__)
+
+__all__ = [
+    "load_anndata",
+    "extract_counts",
+    "build_anndata_dataloader",
+]
+
+
+def load_anndata(
+    path: Union[str, Path],
+    *,
+    backed: Optional[str] = None,
+) -> "AnnData":
+    """
+    Load a local AnnData file from ``.h5ad`` or ``.zarr``.
+
+    Parameters
+    ----------
+    path : str or pathlib.Path
+        Path to a ``.h5ad`` file or a ``.zarr`` store / directory.
+    backed : str, optional
+        Backed mode for ``.h5ad`` (e.g. ``"r"``) to read larger-than-memory
+        files without loading ``X`` fully. Ignored for ``.zarr`` (which is
+        chunked on disk by construction).
+
+    Returns
+    -------
+    anndata.AnnData
+        The loaded AnnData object.
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``path`` does not exist.
+    ValueError
+        If the file extension is not ``.h5ad`` or ``.zarr``.
+    """
+    import anndata as ad
+
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(f"AnnData path does not exist: {p}")
+
+    suffix = p.suffix.lower()
+    if suffix == ".h5ad":
+        return ad.read_h5ad(p, backed=backed)
+    if suffix == ".zarr":
+        return ad.read_zarr(p)
+    raise ValueError(
+        f"Unsupported AnnData extension {suffix!r}; expected .h5ad or .zarr."
+    )
+
+
+def extract_counts(
+    adata: "AnnData",
+    *,
+    layer: Optional[str] = None,
+    var_key: Optional[str] = None,
+) -> Tuple[CountMatrix, List[str]]:
+    """
+    Extract a raw-count matrix and its gene identifiers from an AnnData.
+
+    Parameters
+    ----------
+    adata : anndata.AnnData
+        Source object holding raw counts.
+    layer : str, optional
+        Name of the layer to read counts from. Defaults to ``adata.X``.
+    var_key : str, optional
+        Column in ``adata.var`` providing gene identifiers. Defaults to
+        ``adata.var_names``.
+
+    Returns
+    -------
+    tuple
+        ``(matrix, gene_ids)`` where ``matrix`` is the cell x gene counts and
+        ``gene_ids`` is the list of column gene identifiers.
+    """
+    matrix: CountMatrix = adata.layers[layer] if layer is not None else adata.X
+    if var_key is not None:
+        gene_ids = [str(g) for g in adata.var[var_key].tolist()]
+    else:
+        gene_ids = [str(g) for g in adata.var_names.tolist()]
+    return matrix, gene_ids
+
+
+def build_anndata_dataloader(
+    source: Union[str, Path, "AnnData"],
+    vocabulary: GeneVocabulary,
+    *,
+    batch_size: int = 128,
+    shuffle: bool = False,
+    num_workers: int = 0,
+    layer: Optional[str] = None,
+    var_key: Optional[str] = None,
+    batch_key: Optional[str] = None,
+    min_overlap: float = 0.0,
+    size_factor_mode: str = "total",
+    backed: Optional[str] = None,
+) -> DataLoader:
+    """
+    Build a :class:`~torch.utils.data.DataLoader` over a local AnnData source.
+
+    The returned loader yields :class:`omvqvae.data.dataset.Minibatch` objects,
+    matching the contract shared with the (forthcoming) Census streaming loader.
+
+    Parameters
+    ----------
+    source : str, pathlib.Path, or anndata.AnnData
+        A path to a ``.h5ad`` / ``.zarr`` file, or an in-memory AnnData.
+    vocabulary : GeneVocabulary
+        Organism reference defining the output gene ordering.
+    batch_size : int, default 128
+        Minibatch size.
+    shuffle : bool, default False
+        Whether to shuffle cells each epoch.
+    num_workers : int, default 0
+        Number of DataLoader workers.
+    layer : str, optional
+        AnnData layer to read counts from (default ``adata.X``).
+    var_key : str, optional
+        ``adata.var`` column providing gene ids (default ``var_names``).
+    batch_key : str, optional
+        ``adata.obs`` column carried as the per-cell ``"batch"`` covariate.
+    min_overlap : float, default 0.0
+        Warn-below threshold for reference-gene coverage during alignment.
+    size_factor_mode : str, default "total"
+        Size-factor mode (see
+        :func:`omvqvae.data.normalize.compute_size_factors`).
+    backed : str, optional
+        Backed mode forwarded to :func:`load_anndata` for ``.h5ad`` sources.
+
+    Returns
+    -------
+    torch.utils.data.DataLoader
+        Loader yielding :class:`Minibatch` batches aligned to ``vocabulary``.
+    """
+    if isinstance(source, (str, Path)):
+        adata = load_anndata(source, backed=backed)
+    else:
+        adata = source
+
+    matrix, gene_ids = extract_counts(adata, layer=layer, var_key=var_key)
+    aligned = align_to_reference(matrix, gene_ids, vocabulary, min_overlap=min_overlap)
+
+    batch_ids = (
+        [obj for obj in adata.obs[batch_key].tolist()]
+        if batch_key is not None
+        else None
+    )
+
+    dataset = CountsDataset(
+        aligned,
+        organism=vocabulary.organism,
+        batch_ids=batch_ids,
+        size_factor_mode=size_factor_mode,
+    )
+    return DataLoader(
+        dataset,
+        batch_size=batch_size,
+        shuffle=shuffle,
+        num_workers=num_workers,
+        collate_fn=collate_minibatch,
+    )

--- a/src/omvqvae/data/dataset.py
+++ b/src/omvqvae/data/dataset.py
@@ -1,0 +1,286 @@
+"""
+Organism-aware gene vocabulary, gene-space alignment, and the shared minibatch
+contract for OQAE.
+
+Every data source (local AnnData now; CELLxGENE Census later) is normalized onto
+a single, per-organism feature ordering defined by a :class:`GeneVocabulary`, and
+yields the same ``(counts, covariates)`` minibatch via :class:`Minibatch`. The
+v1 model is unconditional, but the covariates still travel with every batch so
+conditioning can be enabled later without changing the data format.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Mapping, Optional, Sequence
+
+import numpy as np
+import torch
+from torch.utils.data import Dataset
+
+from omvqvae.data.normalize import CountMatrix, compute_size_factors, to_dense
+from omvqvae.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+#: Organisms supported by OQAE v1 (one model per organism).
+SUPPORTED_ORGANISMS = ("homo_sapiens", "mus_musculus")
+
+__all__ = [
+    "SUPPORTED_ORGANISMS",
+    "GeneVocabulary",
+    "align_to_reference",
+    "Minibatch",
+    "CountsDataset",
+    "collate_minibatch",
+]
+
+
+class GeneVocabulary:
+    """
+    An ordered, per-organism reference gene set.
+
+    The vocabulary fixes the feature ordering that the model expects; any data
+    source is aligned to it (missing genes zero-filled, extra genes dropped).
+
+    Parameters
+    ----------
+    organism : str
+        Organism identifier, e.g. ``"homo_sapiens"`` or ``"mus_musculus"``.
+    gene_ids : Iterable[str]
+        Ordered, unique gene identifiers (e.g. Ensembl IDs). Order *is* the
+        model's feature ordering.
+
+    Raises
+    ------
+    ValueError
+        If ``gene_ids`` is empty or contains duplicates.
+    """
+
+    def __init__(self, organism: str, gene_ids: Iterable[str]) -> None:
+        ids = [str(g) for g in gene_ids]
+        if not ids:
+            raise ValueError("GeneVocabulary requires at least one gene id.")
+        index: Dict[str, int] = {}
+        for pos, gene in enumerate(ids):
+            if gene in index:
+                raise ValueError(f"Duplicate gene id in vocabulary: {gene!r}.")
+            index[gene] = pos
+        if organism not in SUPPORTED_ORGANISMS:
+            logger.warning(
+                "Organism %r is not in the v1-supported set %s.",
+                organism,
+                SUPPORTED_ORGANISMS,
+            )
+        self.organism = organism
+        self._gene_ids = ids
+        self._index = index
+
+    @property
+    def gene_ids(self) -> List[str]:
+        """Ordered reference gene identifiers."""
+        return list(self._gene_ids)
+
+    @property
+    def n_genes(self) -> int:
+        """Number of genes in the reference."""
+        return len(self._gene_ids)
+
+    def position_of(self, gene_id: str) -> Optional[int]:
+        """Return the reference position of ``gene_id`` (or ``None``)."""
+        return self._index.get(str(gene_id))
+
+    def __len__(self) -> int:
+        return self.n_genes
+
+    def __repr__(self) -> str:  # pragma: no cover - debug convenience
+        return f"GeneVocabulary(organism={self.organism!r}, " f"n_genes={self.n_genes})"
+
+
+def align_to_reference(
+    matrix: CountMatrix,
+    source_gene_ids: Sequence[str],
+    vocabulary: GeneVocabulary,
+    *,
+    min_overlap: float = 0.0,
+) -> np.ndarray:
+    """
+    Align a source count matrix onto a reference gene vocabulary.
+
+    Genes present in the reference but missing from the source are zero-filled;
+    genes present in the source but absent from the reference are dropped.
+
+    Parameters
+    ----------
+    matrix : numpy.ndarray or scipy.sparse.spmatrix
+        Source count matrix of shape ``(n_cells, len(source_gene_ids))``.
+    source_gene_ids : Sequence[str]
+        Gene identifiers labelling the columns of ``matrix``.
+    vocabulary : GeneVocabulary
+        Target reference defining the output column ordering.
+    min_overlap : float, default 0.0
+        Warn when the fraction of *reference* genes covered by the source falls
+        below this threshold (in ``[0, 1]``).
+
+    Returns
+    -------
+    numpy.ndarray
+        Aligned matrix of shape ``(n_cells, vocabulary.n_genes)`` as ``float32``.
+
+    Raises
+    ------
+    ValueError
+        If ``matrix`` column count does not match ``len(source_gene_ids)``.
+    """
+    n_cells = matrix.shape[0]
+    n_source_cols = matrix.shape[1]
+    if n_source_cols != len(source_gene_ids):
+        raise ValueError(
+            "matrix has "
+            f"{n_source_cols} columns but {len(source_gene_ids)} gene ids "
+            "were provided."
+        )
+
+    src_positions: List[int] = []
+    ref_positions: List[int] = []
+    for col, gene in enumerate(source_gene_ids):
+        ref_pos = vocabulary.position_of(gene)
+        if ref_pos is not None:
+            src_positions.append(col)
+            ref_positions.append(ref_pos)
+
+    n_matched = len(ref_positions)
+    overlap = n_matched / vocabulary.n_genes if vocabulary.n_genes else 0.0
+    if overlap < min_overlap:
+        logger.warning(
+            "Low gene overlap for organism %r: %d/%d reference genes matched "
+            "(%.1f%% < %.1f%% threshold).",
+            vocabulary.organism,
+            n_matched,
+            vocabulary.n_genes,
+            overlap * 100.0,
+            min_overlap * 100.0,
+        )
+    else:
+        logger.info(
+            "Aligned %d/%d reference genes (%.1f%% coverage) for organism %r.",
+            n_matched,
+            vocabulary.n_genes,
+            overlap * 100.0,
+            vocabulary.organism,
+        )
+
+    aligned = np.zeros((n_cells, vocabulary.n_genes), dtype=np.float32)
+    if n_matched:
+        dense = to_dense(matrix)
+        aligned[:, ref_positions] = dense[:, src_positions]
+    return aligned
+
+
+@dataclass
+class Minibatch:
+    """
+    The shared minibatch contract produced by every OQAE data source.
+
+    Attributes
+    ----------
+    counts : torch.Tensor
+        Raw counts of shape ``(batch, n_genes)`` (``float32``), aligned to the
+        organism's :class:`GeneVocabulary`.
+    size_factors : torch.Tensor
+        Per-cell size factors of shape ``(batch,)`` (``float32``).
+    covariates : Dict[str, List[object]]
+        Per-cell metadata carried with the batch (always includes
+        ``"organism"``; typically a ``"batch"`` / dataset id). Unused by the v1
+        unconditional model but available for later conditioning.
+    """
+
+    counts: torch.Tensor
+    size_factors: torch.Tensor
+    covariates: Dict[str, List[object]]
+
+    def __len__(self) -> int:
+        return int(self.counts.shape[0])
+
+
+class CountsDataset(Dataset[Mapping[str, object]]):
+    """
+    In-memory :class:`torch.utils.data.Dataset` over aligned raw counts.
+
+    Parameters
+    ----------
+    counts : numpy.ndarray or scipy.sparse.spmatrix
+        Count matrix of shape ``(n_cells, n_genes)``, already aligned to the
+        reference vocabulary.
+    organism : str
+        Organism identifier recorded on every sample.
+    batch_ids : Sequence, optional
+        Per-cell batch / dataset identifier. Defaults to ``None`` for every cell.
+    size_factor_mode : str, default "total"
+        Mode passed to :func:`omvqvae.data.normalize.compute_size_factors`.
+
+    Raises
+    ------
+    ValueError
+        If ``batch_ids`` length does not match the number of cells.
+    """
+
+    def __init__(
+        self,
+        counts: CountMatrix,
+        organism: str,
+        *,
+        batch_ids: Optional[Sequence[object]] = None,
+        size_factor_mode: str = "total",
+    ) -> None:
+        self._counts = to_dense(counts)
+        self.organism = organism
+        n_cells = self._counts.shape[0]
+        if batch_ids is None:
+            self._batch_ids: List[object] = [None] * n_cells
+        else:
+            batch_list = list(batch_ids)
+            if len(batch_list) != n_cells:
+                raise ValueError(
+                    f"batch_ids has length {len(batch_list)} but there are "
+                    f"{n_cells} cells."
+                )
+            self._batch_ids = batch_list
+        self._size_factors = compute_size_factors(self._counts, mode=size_factor_mode)
+
+    def __len__(self) -> int:
+        return int(self._counts.shape[0])
+
+    def __getitem__(self, index: int) -> Dict[str, object]:
+        return {
+            "counts": torch.from_numpy(self._counts[index].copy()),
+            "size_factor": torch.tensor(
+                float(self._size_factors[index]), dtype=torch.float32
+            ),
+            "organism": self.organism,
+            "batch": self._batch_ids[index],
+        }
+
+
+def collate_minibatch(samples: Sequence[Mapping[str, object]]) -> Minibatch:
+    """
+    Collate per-cell samples into a :class:`Minibatch`.
+
+    Parameters
+    ----------
+    samples : Sequence[Mapping[str, object]]
+        Samples as produced by :class:`CountsDataset` (or any source emitting the
+        same keys: ``counts``, ``size_factor``, ``organism``, ``batch``).
+
+    Returns
+    -------
+    Minibatch
+        Stacked counts/size-factors with collated covariates.
+    """
+    counts = torch.stack([torch.as_tensor(s["counts"]) for s in samples])
+    size_factors = torch.stack([torch.as_tensor(s["size_factor"]) for s in samples])
+    covariates: Dict[str, List[object]] = {
+        "organism": [s["organism"] for s in samples],
+        "batch": [s["batch"] for s in samples],
+    }
+    return Minibatch(counts=counts, size_factors=size_factors, covariates=covariates)

--- a/src/omvqvae/data/normalize.py
+++ b/src/omvqvae/data/normalize.py
@@ -1,0 +1,175 @@
+"""
+Internal normalization and size-factor helpers for OQAE.
+
+OQAE ingests **raw counts** and performs normalization *internally* (scVI-style):
+the model reconstructs counts with a count likelihood (NB/ZINB) using an observed
+size factor, while the encoder applies an internal ``log1p`` (and optional
+per-cell normalization) purely for numerical stability. None of these are
+user-facing preprocessing steps — they live here so the rest of the pipeline can
+share a single, tested implementation.
+
+All helpers accept either a dense :class:`numpy.ndarray` or a SciPy sparse matrix
+(cell x gene) and return dense :class:`numpy.ndarray` results.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Union
+
+import numpy as np
+from scipy import sparse
+
+from omvqvae.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+# A cell x gene count matrix, dense or sparse.
+CountMatrix = Union[np.ndarray, "sparse.spmatrix"]
+
+__all__ = [
+    "CountMatrix",
+    "compute_size_factors",
+    "normalize_counts",
+    "to_dense",
+]
+
+
+def to_dense(matrix: CountMatrix) -> np.ndarray:
+    """
+    Return a dense ``float32`` view/copy of ``matrix``.
+
+    Parameters
+    ----------
+    matrix : numpy.ndarray or scipy.sparse.spmatrix
+        Cell x gene count matrix.
+
+    Returns
+    -------
+    numpy.ndarray
+        Dense ``float32`` array with the same shape as ``matrix``.
+    """
+    if sparse.issparse(matrix):
+        dense: np.ndarray = matrix.toarray()  # type: ignore[union-attr]
+    else:
+        dense = np.asarray(matrix)
+    return dense.astype(np.float32, copy=False)
+
+
+def _row_sums(matrix: CountMatrix) -> np.ndarray:
+    """Compute per-cell (row) total counts as a 1-D ``float64`` array."""
+    if sparse.issparse(matrix):
+        sums = np.asarray(matrix.sum(axis=1)).ravel()
+    else:
+        sums = np.asarray(matrix).sum(axis=1).ravel()
+    return sums.astype(np.float64, copy=False)
+
+
+def compute_size_factors(
+    matrix: CountMatrix,
+    *,
+    mode: str = "total",
+    target_sum: Union[float, None] = None,
+) -> np.ndarray:
+    """
+    Compute a per-cell size factor from observed total counts.
+
+    The size factor captures sequencing-depth / library-size variation so the
+    generative decoder can reconstruct depth-appropriate counts.
+
+    Parameters
+    ----------
+    matrix : numpy.ndarray or scipy.sparse.spmatrix
+        Raw count matrix of shape ``(n_cells, n_genes)``.
+    mode : {"total", "ratio"}, default "total"
+        ``"total"`` returns the raw per-cell total counts. ``"ratio"`` returns
+        each cell's total divided by ``target_sum`` (or the median total when
+        ``target_sum`` is ``None``), yielding factors centred near 1.0.
+    target_sum : float, optional
+        Reference depth used when ``mode="ratio"``. Defaults to the median of the
+        per-cell totals.
+
+    Returns
+    -------
+    numpy.ndarray
+        Size factors of shape ``(n_cells,)`` as ``float32``. Cells with zero
+        total counts receive a size factor of 1.0 to avoid divide-by-zero
+        downstream.
+
+    Raises
+    ------
+    ValueError
+        If ``mode`` is not one of ``{"total", "ratio"}``.
+    """
+    totals = _row_sums(matrix)
+
+    if mode == "total":
+        factors = totals
+    elif mode == "ratio":
+        reference = target_sum
+        if reference is None:
+            positive = totals[totals > 0]
+            reference = float(np.median(positive)) if positive.size else 1.0
+        if reference <= 0:
+            raise ValueError("target_sum must be positive.")
+        factors = totals / reference
+    else:
+        raise ValueError(f"Unknown size-factor mode: {mode!r}.")
+
+    # Guard against empty cells so downstream division stays finite.
+    factors = np.where(totals > 0, factors, 1.0)
+    return factors.astype(np.float32, copy=False)
+
+
+def normalize_counts(
+    matrix: CountMatrix,
+    *,
+    target_sum: Union[float, None] = 1e4,
+    log1p: bool = True,
+    size_factors: Union[np.ndarray, None] = None,
+) -> np.ndarray:
+    """
+    Apply OQAE's internal normalization to raw counts.
+
+    Each cell is optionally rescaled to a common depth and then ``log1p``
+    transformed. This mirrors the encoder's internal transform and is provided
+    here so it can be reused and unit-tested in isolation.
+
+    Parameters
+    ----------
+    matrix : numpy.ndarray or scipy.sparse.spmatrix
+        Raw count matrix of shape ``(n_cells, n_genes)``.
+    target_sum : float, optional
+        Per-cell total to normalize to before the log transform. If ``None``, no
+        depth normalization is applied (only the optional ``log1p``).
+    log1p : bool, default True
+        Whether to apply ``log1p`` after (optional) depth normalization.
+    size_factors : numpy.ndarray, optional
+        Pre-computed per-cell totals of shape ``(n_cells,)``. When ``None`` and
+        ``target_sum`` is set, totals are computed from ``matrix``.
+
+    Returns
+    -------
+    numpy.ndarray
+        Normalized matrix of shape ``(n_cells, n_genes)`` as ``float32``.
+    """
+    dense = to_dense(matrix)
+
+    if target_sum is not None:
+        if size_factors is None:
+            totals = dense.sum(axis=1)
+        else:
+            totals = np.asarray(size_factors, dtype=np.float64).ravel()
+        safe_totals = np.where(totals > 0, totals, 1.0)
+        dense = dense / safe_totals[:, None] * float(target_sum)
+
+    if log1p:
+        dense = np.log1p(dense)
+
+    return dense.astype(np.float32, copy=False)
+
+
+def _is_count_like(matrix: Any) -> bool:  # pragma: no cover - convenience guard
+    """Best-effort check that values look like non-negative counts."""
+    sample = to_dense(matrix) if not sparse.issparse(matrix) else matrix.data
+    arr = np.asarray(sample)
+    return bool(arr.size == 0 or arr.min() >= 0)

--- a/tests/data/conftest.py
+++ b/tests/data/conftest.py
@@ -1,0 +1,43 @@
+"""Shared offline fixtures for OQAE data-layer tests."""
+
+from __future__ import annotations
+
+from typing import List
+
+import numpy as np
+import pytest
+from anndata import AnnData
+from scipy import sparse
+
+
+def make_anndata(
+    *,
+    n_cells: int = 6,
+    gene_ids: List[str],
+    seed: int = 0,
+    sparse_x: bool = True,
+    add_batch: bool = True,
+) -> AnnData:
+    """Build a tiny synthetic raw-count AnnData for offline tests."""
+    import pandas as pd
+
+    rng = np.random.default_rng(seed)
+    counts = rng.poisson(lam=2.0, size=(n_cells, len(gene_ids))).astype(np.float32)
+    x: object = sparse.csr_matrix(counts) if sparse_x else counts
+    obs = pd.DataFrame(index=[f"cell_{i}" for i in range(n_cells)])
+    if add_batch:
+        obs["batch"] = [f"b{i % 2}" for i in range(n_cells)]
+    var = pd.DataFrame(index=list(gene_ids))
+    return AnnData(X=x, obs=obs, var=var)
+
+
+@pytest.fixture
+def human_gene_ids() -> List[str]:
+    """A small ordered human reference gene set."""
+    return ["ENSG1", "ENSG2", "ENSG3", "ENSG4"]
+
+
+@pytest.fixture
+def mouse_gene_ids() -> List[str]:
+    """A small ordered mouse reference gene set."""
+    return ["ENSMUSG1", "ENSMUSG2", "ENSMUSG3"]

--- a/tests/data/test_anndata_io.py
+++ b/tests/data/test_anndata_io.py
@@ -1,0 +1,115 @@
+"""Tests for local AnnData loading and the DataLoader factory."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+import pytest
+
+from omvqvae.data.anndata_io import (
+    build_anndata_dataloader,
+    extract_counts,
+    load_anndata,
+)
+from omvqvae.data.dataset import GeneVocabulary, Minibatch
+
+from .conftest import make_anndata
+
+
+def test_load_anndata_h5ad_roundtrip(tmp_path: Path, human_gene_ids: List[str]) -> None:
+    adata = make_anndata(gene_ids=human_gene_ids)
+    path = tmp_path / "data.h5ad"
+    adata.write_h5ad(path)
+    loaded = load_anndata(path)
+    assert list(loaded.var_names) == human_gene_ids
+    assert loaded.n_obs == adata.n_obs
+
+
+def test_load_anndata_zarr_roundtrip(tmp_path: Path, human_gene_ids: List[str]) -> None:
+    adata = make_anndata(gene_ids=human_gene_ids, sparse_x=False)
+    path = tmp_path / "data.zarr"
+    adata.write_zarr(path)
+    loaded = load_anndata(path)
+    assert list(loaded.var_names) == human_gene_ids
+
+
+def test_load_anndata_missing_file(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        load_anndata(tmp_path / "nope.h5ad")
+
+
+def test_load_anndata_bad_extension(tmp_path: Path) -> None:
+    bad = tmp_path / "data.txt"
+    bad.write_text("not anndata")
+    with pytest.raises(ValueError, match="Unsupported"):
+        load_anndata(bad)
+
+
+def test_extract_counts_var_names_and_layer(human_gene_ids: List[str]) -> None:
+    adata = make_anndata(gene_ids=human_gene_ids, sparse_x=False)
+    adata.layers["counts"] = adata.X.copy()
+    matrix, gene_ids = extract_counts(adata, layer="counts")
+    assert gene_ids == human_gene_ids
+    assert matrix.shape == (adata.n_obs, len(human_gene_ids))
+
+
+def test_extract_counts_with_var_key(human_gene_ids: List[str]) -> None:
+    adata = make_anndata(gene_ids=human_gene_ids, sparse_x=False)
+    adata.var["gene_symbol"] = [f"SYM_{g}" for g in human_gene_ids]
+    _, gene_ids = extract_counts(adata, var_key="gene_symbol")
+    assert gene_ids == [f"SYM_{g}" for g in human_gene_ids]
+
+
+def test_build_dataloader_from_in_memory_anndata(
+    human_gene_ids: List[str],
+) -> None:
+    adata = make_anndata(gene_ids=human_gene_ids, n_cells=6)
+    vocab = GeneVocabulary("homo_sapiens", human_gene_ids)
+    loader = build_anndata_dataloader(adata, vocab, batch_size=4, batch_key="batch")
+    batches = list(loader)
+    assert sum(len(b) for b in batches) == 6
+    first = batches[0]
+    assert isinstance(first, Minibatch)
+    assert first.counts.shape[1] == vocab.n_genes
+    assert first.covariates["organism"][0] == "homo_sapiens"
+    assert set(first.covariates["batch"]) <= {"b0", "b1"}
+
+
+def test_build_dataloader_aligns_to_reference(human_gene_ids: List[str]) -> None:
+    # Reference has an extra gene the source lacks -> zero-filled column.
+    reference = human_gene_ids + ["ENSG_EXTRA"]
+    adata = make_anndata(gene_ids=human_gene_ids, n_cells=3, sparse_x=False)
+    vocab = GeneVocabulary("homo_sapiens", reference)
+    loader = build_anndata_dataloader(adata, vocab, batch_size=8)
+    batch = next(iter(loader))
+    assert batch.counts.shape == (3, len(reference))
+    # The extra reference gene (last column) is zero for every cell.
+    assert float(batch.counts[:, -1].abs().sum()) == 0.0
+
+
+def test_build_dataloader_from_path(tmp_path: Path, human_gene_ids: List[str]) -> None:
+    adata = make_anndata(gene_ids=human_gene_ids)
+    path = tmp_path / "data.h5ad"
+    adata.write_h5ad(path)
+    vocab = GeneVocabulary("homo_sapiens", human_gene_ids)
+    loader = build_anndata_dataloader(path, vocab, batch_size=2)
+    assert sum(len(b) for b in loader) == adata.n_obs
+
+
+def test_human_and_mouse_share_same_api(
+    human_gene_ids: List[str], mouse_gene_ids: List[str]
+) -> None:
+    """The exit criterion: human and mouse iterate through the same API."""
+    human = make_anndata(gene_ids=human_gene_ids, n_cells=5)
+    mouse = make_anndata(gene_ids=mouse_gene_ids, n_cells=4, seed=1)
+    for adata, organism, genes in [
+        (human, "homo_sapiens", human_gene_ids),
+        (mouse, "mus_musculus", mouse_gene_ids),
+    ]:
+        vocab = GeneVocabulary(organism, genes)
+        loader = build_anndata_dataloader(adata, vocab, batch_size=3)
+        batch = next(iter(loader))
+        assert isinstance(batch, Minibatch)
+        assert batch.counts.shape[1] == len(genes)
+        assert batch.covariates["organism"][0] == organism

--- a/tests/data/test_dataset.py
+++ b/tests/data/test_dataset.py
@@ -1,0 +1,121 @@
+"""Tests for the gene vocabulary, alignment, and minibatch contract."""
+
+from __future__ import annotations
+
+import logging
+from typing import List
+
+import numpy as np
+import pytest
+import torch
+from scipy import sparse
+
+from omvqvae.data.dataset import (
+    SUPPORTED_ORGANISMS,
+    CountsDataset,
+    GeneVocabulary,
+    Minibatch,
+    align_to_reference,
+    collate_minibatch,
+)
+
+
+def test_gene_vocabulary_basics() -> None:
+    vocab = GeneVocabulary("homo_sapiens", ["A", "B", "C"])
+    assert vocab.n_genes == 3
+    assert len(vocab) == 3
+    assert vocab.gene_ids == ["A", "B", "C"]
+    assert vocab.position_of("B") == 1
+    assert vocab.position_of("missing") is None
+    assert "homo_sapiens" in SUPPORTED_ORGANISMS
+
+
+def test_gene_vocabulary_rejects_empty_and_duplicates() -> None:
+    with pytest.raises(ValueError, match="at least one"):
+        GeneVocabulary("homo_sapiens", [])
+    with pytest.raises(ValueError, match="Duplicate"):
+        GeneVocabulary("homo_sapiens", ["A", "A"])
+
+
+def test_gene_vocabulary_warns_on_unsupported_organism(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.WARNING):
+        GeneVocabulary("danio_rerio", ["A"])
+    assert any("not in the v1-supported" in r.message for r in caplog.records)
+
+
+def test_align_to_reference_zero_fill_drop_reorder() -> None:
+    vocab = GeneVocabulary("homo_sapiens", ["A", "B", "C", "D"])
+    # Source carries C, A, X (X is extra), in a different order.
+    matrix = np.array([[10, 20, 99]], dtype=np.float32)
+    aligned = align_to_reference(matrix, ["C", "A", "X"], vocab)
+    # A->20 at col0, B->0, C->10 at col2, D->0; X dropped.
+    np.testing.assert_array_equal(aligned[0], [20.0, 0.0, 10.0, 0.0])
+    assert aligned.shape == (1, 4)
+    assert aligned.dtype == np.float32
+
+
+def test_align_to_reference_accepts_sparse() -> None:
+    vocab = GeneVocabulary("homo_sapiens", ["A", "B"])
+    matrix = sparse.csr_matrix(np.array([[5, 7]], dtype=np.float32))
+    aligned = align_to_reference(matrix, ["A", "B"], vocab)
+    np.testing.assert_array_equal(aligned[0], [5.0, 7.0])
+
+
+def test_align_to_reference_low_overlap_warns(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    vocab = GeneVocabulary("homo_sapiens", ["A", "B", "C", "D"])
+    matrix = np.array([[1.0]], dtype=np.float32)
+    with caplog.at_level(logging.WARNING):
+        align_to_reference(matrix, ["A"], vocab, min_overlap=0.9)
+    assert any("Low gene overlap" in r.message for r in caplog.records)
+
+
+def test_align_to_reference_column_mismatch() -> None:
+    vocab = GeneVocabulary("homo_sapiens", ["A", "B"])
+    with pytest.raises(ValueError, match="columns"):
+        align_to_reference(np.ones((1, 3), dtype=np.float32), ["A", "B"], vocab)
+
+
+def test_counts_dataset_getitem_and_len() -> None:
+    counts = np.array([[1, 2, 3], [4, 0, 0]], dtype=np.float32)
+    ds = CountsDataset(counts, organism="mus_musculus", batch_ids=["x", "y"])
+    assert len(ds) == 2
+    sample = ds[0]
+    assert isinstance(sample["counts"], torch.Tensor)
+    assert sample["counts"].shape == (3,)
+    assert pytest.approx(float(sample["size_factor"])) == 6.0
+    assert sample["organism"] == "mus_musculus"
+    assert sample["batch"] == "x"
+
+
+def test_counts_dataset_default_batch_ids() -> None:
+    ds = CountsDataset(np.ones((3, 2), dtype=np.float32), organism="homo_sapiens")
+    assert ds[2]["batch"] is None
+
+
+def test_counts_dataset_batch_length_mismatch() -> None:
+    with pytest.raises(ValueError, match="batch_ids"):
+        CountsDataset(
+            np.ones((2, 2), dtype=np.float32),
+            organism="homo_sapiens",
+            batch_ids=["only_one"],
+        )
+
+
+def _samples() -> List[dict]:
+    counts = np.array([[1, 2], [3, 4], [5, 6]], dtype=np.float32)
+    ds = CountsDataset(counts, organism="homo_sapiens", batch_ids=["a", "b", "c"])
+    return [ds[i] for i in range(len(ds))]
+
+
+def test_collate_minibatch_shapes_and_covariates() -> None:
+    batch = collate_minibatch(_samples())
+    assert isinstance(batch, Minibatch)
+    assert batch.counts.shape == (3, 2)
+    assert batch.size_factors.shape == (3,)
+    assert len(batch) == 3
+    assert batch.covariates["organism"] == ["homo_sapiens"] * 3
+    assert batch.covariates["batch"] == ["a", "b", "c"]

--- a/tests/data/test_normalize.py
+++ b/tests/data/test_normalize.py
@@ -1,0 +1,89 @@
+"""Tests for OQAE internal normalization / size-factor helpers."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from scipy import sparse
+
+from omvqvae.data.normalize import (
+    compute_size_factors,
+    normalize_counts,
+    to_dense,
+)
+
+
+def test_to_dense_from_sparse_and_dense() -> None:
+    arr = np.array([[1, 2], [3, 4]], dtype=np.float64)
+    dense = to_dense(arr)
+    assert dense.dtype == np.float32
+    np.testing.assert_array_equal(dense, arr)
+
+    spm = sparse.csr_matrix(arr)
+    dense_sp = to_dense(spm)
+    assert dense_sp.dtype == np.float32
+    np.testing.assert_array_equal(dense_sp, arr)
+
+
+def test_compute_size_factors_total() -> None:
+    counts = np.array([[1, 2, 3], [0, 0, 0], [4, 0, 1]], dtype=np.float32)
+    factors = compute_size_factors(counts, mode="total")
+    # Empty cell gets 1.0 to stay finite.
+    np.testing.assert_allclose(factors, [6.0, 1.0, 5.0])
+    assert factors.dtype == np.float32
+
+
+def test_compute_size_factors_ratio_default_median() -> None:
+    counts = np.array([[10, 0], [0, 30], [20, 0]], dtype=np.float32)
+    factors = compute_size_factors(counts, mode="ratio")
+    # Totals are 10, 30, 20; median is 20 -> factors 0.5, 1.5, 1.0.
+    np.testing.assert_allclose(factors, [0.5, 1.5, 1.0])
+
+
+def test_compute_size_factors_ratio_explicit_target() -> None:
+    counts = np.array([[5], [10]], dtype=np.float32)
+    factors = compute_size_factors(counts, mode="ratio", target_sum=10.0)
+    np.testing.assert_allclose(factors, [0.5, 1.0])
+
+
+def test_compute_size_factors_sparse_matches_dense() -> None:
+    counts = np.array([[1, 2, 0], [3, 0, 5]], dtype=np.float32)
+    dense = compute_size_factors(counts, mode="total")
+    spm = compute_size_factors(sparse.csr_matrix(counts), mode="total")
+    np.testing.assert_array_equal(dense, spm)
+
+
+def test_compute_size_factors_invalid_mode() -> None:
+    with pytest.raises(ValueError, match="mode"):
+        compute_size_factors(np.ones((2, 2), dtype=np.float32), mode="bogus")
+
+
+def test_compute_size_factors_ratio_nonpositive_target() -> None:
+    with pytest.raises(ValueError, match="positive"):
+        compute_size_factors(
+            np.ones((2, 2), dtype=np.float32), mode="ratio", target_sum=0.0
+        )
+
+
+def test_normalize_counts_log1p_and_target_sum() -> None:
+    counts = np.array([[1, 1, 2], [0, 0, 0]], dtype=np.float32)
+    out = normalize_counts(counts, target_sum=4.0, log1p=True)
+    # Row 0 total 4 -> scaled to [1, 1, 2] -> log1p.
+    np.testing.assert_allclose(out[0], np.log1p([1.0, 1.0, 2.0]), rtol=1e-6)
+    # Empty row stays all-zero (safe division).
+    np.testing.assert_array_equal(out[1], np.zeros(3, dtype=np.float32))
+    assert out.dtype == np.float32
+
+
+def test_normalize_counts_no_target_sum_only_log1p() -> None:
+    counts = np.array([[3, 0]], dtype=np.float32)
+    out = normalize_counts(counts, target_sum=None, log1p=True)
+    np.testing.assert_allclose(out[0], np.log1p([3.0, 0.0]))
+
+
+def test_normalize_counts_with_supplied_size_factors() -> None:
+    counts = np.array([[2, 2]], dtype=np.float32)
+    out = normalize_counts(
+        counts, target_sum=2.0, log1p=False, size_factors=np.array([4.0])
+    )
+    np.testing.assert_allclose(out[0], [1.0, 1.0])

--- a/uv.lock
+++ b/uv.lock
@@ -51,6 +51,12 @@ wheels = [
 ]
 
 [[package]]
+name = "asciitree"
+version = "0.3.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/6a/885bc91484e1aa8f618f6f0228d76d0e67000b0fdd6090673b777e311913/asciitree-0.3.3.tar.gz", hash = "sha256:4aa4b9b649f85e3fcb343363d97564aa1fb62e249677f2e18a96765145cc0f6e", size = 3951, upload-time = "2016-09-05T19:10:42.681Z" }
+
+[[package]]
 name = "autopep8"
 version = "2.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -246,58 +252,6 @@ toml = [
 ]
 
 [[package]]
-name = "crc32c"
-version = "2.7.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7f/4c/4e40cc26347ac8254d3f25b9f94710b8e8df24ee4dddc1ba41907a88a94d/crc32c-2.7.1.tar.gz", hash = "sha256:f91b144a21eef834d64178e01982bb9179c354b3e9e5f4c803b0e5096384968c", size = 45712, upload-time = "2024-09-24T06:20:17.553Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/8e/2f37f46368bbfd50edfc11b96f0aa135699034b1b020966c70ebaff3463b/crc32c-2.7.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:19e03a50545a3ef400bd41667d5525f71030488629c57d819e2dd45064f16192", size = 49672, upload-time = "2024-09-24T06:18:18.032Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/b8/e52f7c4b045b871c2984d70f37c31d4861b533a8082912dfd107a96cf7c1/crc32c-2.7.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8c03286b1e5ce9bed7090084f206aacd87c5146b4b10de56fe9e86cbbbf851cf", size = 37155, upload-time = "2024-09-24T06:18:19.373Z" },
-    { url = "https://files.pythonhosted.org/packages/25/ee/0cfa82a68736697f3c7e435ba658c2ef8c997f42b89f6ab4545efe1b2649/crc32c-2.7.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:80ebbf144a1a56a532b353e81fa0f3edca4f4baa1bf92b1dde2c663a32bb6a15", size = 35372, upload-time = "2024-09-24T06:18:20.983Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/92/c878aaba81c431fcd93a059e9f6c90db397c585742793f0bf6e0c531cc67/crc32c-2.7.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:96b794fd11945298fdd5eb1290a812efb497c14bc42592c5c992ca077458eeba", size = 54879, upload-time = "2024-09-24T06:18:23.085Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/f5/ab828ab3907095e06b18918408748950a9f726ee2b37be1b0839fb925ee1/crc32c-2.7.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9df7194dd3c0efb5a21f5d70595b7a8b4fd9921fbbd597d6d8e7a11eca3e2d27", size = 52588, upload-time = "2024-09-24T06:18:24.463Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/2b/9e29e9ac4c4213d60491db09487125db358cd9263490fbadbd55e48fbe03/crc32c-2.7.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d698eec444b18e296a104d0b9bb6c596c38bdcb79d24eba49604636e9d747305", size = 53674, upload-time = "2024-09-24T06:18:25.624Z" },
-    { url = "https://files.pythonhosted.org/packages/79/ed/df3c4c14bf1b29f5c9b52d51fb6793e39efcffd80b2941d994e8f7f5f688/crc32c-2.7.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e07cf10ef852d219d179333fd706d1c415626f1f05e60bd75acf0143a4d8b225", size = 54691, upload-time = "2024-09-24T06:18:26.578Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/47/4917af3c9c1df2fff28bbfa6492673c9adeae5599dcc207bbe209847489c/crc32c-2.7.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:d2a051f296e6e92e13efee3b41db388931cdb4a2800656cd1ed1d9fe4f13a086", size = 52896, upload-time = "2024-09-24T06:18:28.174Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/6f/26fc3dda5835cda8f6cd9d856afe62bdeae428de4c34fea200b0888e8835/crc32c-2.7.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a1738259802978cdf428f74156175da6a5fdfb7256f647fdc0c9de1bc6cd7173", size = 53554, upload-time = "2024-09-24T06:18:29.104Z" },
-    { url = "https://files.pythonhosted.org/packages/56/3e/6f39127f7027c75d130c0ba348d86a6150dff23761fbc6a5f71659f4521e/crc32c-2.7.1-cp311-cp311-win32.whl", hash = "sha256:f7786d219a1a1bf27d0aa1869821d11a6f8e90415cfffc1e37791690d4a848a1", size = 38370, upload-time = "2024-09-24T06:18:30.013Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/fb/1587c2705a3a47a3d0067eecf9a6fec510761c96dec45c7b038fb5c8ff46/crc32c-2.7.1-cp311-cp311-win_amd64.whl", hash = "sha256:887f6844bb3ad35f0778cd10793ad217f7123a5422e40041231b8c4c7329649d", size = 39795, upload-time = "2024-09-24T06:18:31.324Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/02/998dc21333413ce63fe4c1ca70eafe61ca26afc7eb353f20cecdb77d614e/crc32c-2.7.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:f7d1c4e761fe42bf856130daf8b2658df33fe0ced3c43dadafdfeaa42b57b950", size = 49568, upload-time = "2024-09-24T06:18:32.425Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/3e/e3656bfa76e50ef87b7136fef2dbf3c46e225629432fc9184fdd7fd187ff/crc32c-2.7.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:73361c79a6e4605204457f19fda18b042a94508a52e53d10a4239da5fb0f6a34", size = 37019, upload-time = "2024-09-24T06:18:34.097Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/7d/5ff9904046ad15a08772515db19df43107bf5e3901a89c36a577b5f40ba0/crc32c-2.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:afd778fc8ac0ed2ffbfb122a9aa6a0e409a8019b894a1799cda12c01534493e0", size = 35373, upload-time = "2024-09-24T06:18:35.02Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/41/4aedc961893f26858ab89fc772d0eaba91f9870f19eaa933999dcacb94ec/crc32c-2.7.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:56ef661b34e9f25991fface7f9ad85e81bbc1b3fe3b916fd58c893eabe2fa0b8", size = 54675, upload-time = "2024-09-24T06:18:35.954Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/63/8cabf09b7e39b9fec8f7010646c8b33057fc8d67e6093b3cc15563d23533/crc32c-2.7.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:571aa4429444b5d7f588e4377663592145d2d25eb1635abb530f1281794fc7c9", size = 52386, upload-time = "2024-09-24T06:18:36.896Z" },
-    { url = "https://files.pythonhosted.org/packages/79/13/13576941bf7cf95026abae43d8427c812c0054408212bf8ed490eda846b0/crc32c-2.7.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c02a3bd67dea95cdb25844aaf44ca2e1b0c1fd70b287ad08c874a95ef4bb38db", size = 53495, upload-time = "2024-09-24T06:18:38.099Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/b6/55ffb26d0517d2d6c6f430ce2ad36ae7647c995c5bfd7abce7f32bb2bad1/crc32c-2.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:99d17637c4867672cb8adeea007294e3c3df9d43964369516cfe2c1f47ce500a", size = 54456, upload-time = "2024-09-24T06:18:39.051Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/1a/5562e54cb629ecc5543d3604dba86ddfc7c7b7bf31d64005b38a00d31d31/crc32c-2.7.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:f4a400ac3c69a32e180d8753fd7ec7bccb80ade7ab0812855dce8a208e72495f", size = 52647, upload-time = "2024-09-24T06:18:40.021Z" },
-    { url = "https://files.pythonhosted.org/packages/48/ec/ce4138eaf356cd9aae60bbe931755e5e0151b3eca5f491fce6c01b97fd59/crc32c-2.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:588587772e55624dd9c7a906ec9e8773ae0b6ac5e270fc0bc84ee2758eba90d5", size = 53332, upload-time = "2024-09-24T06:18:40.925Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/b5/144b42cd838a901175a916078781cb2c3c9f977151c9ba085aebd6d15b22/crc32c-2.7.1-cp312-cp312-win32.whl", hash = "sha256:9f14b60e5a14206e8173dd617fa0c4df35e098a305594082f930dae5488da428", size = 38371, upload-time = "2024-09-24T06:18:42.711Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/c4/7929dcd5d9b57db0cce4fe6f6c191049380fc6d8c9b9f5581967f4ec018e/crc32c-2.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:7c810a246660a24dc818047dc5f89c7ce7b2814e1e08a8e99993f4103f7219e8", size = 39805, upload-time = "2024-09-24T06:18:43.6Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/98/1a6d60d5b3b5edc8382777b64100343cb4aa6a7e172fae4a6cfcb8ebbbd9/crc32c-2.7.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:24949bffb06fc411cc18188d33357923cb935273642164d0bb37a5f375654169", size = 49567, upload-time = "2024-09-24T06:18:44.485Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/56/0dd652d4e950e6348bbf16b964b3325e4ad8220470774128fc0b0dd069cb/crc32c-2.7.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2d5d326e7e118d4fa60187770d86b66af2fdfc63ce9eeb265f0d3e7d49bebe0b", size = 37018, upload-time = "2024-09-24T06:18:45.434Z" },
-    { url = "https://files.pythonhosted.org/packages/47/02/2bd65fdef10139b6a802d83a7f966b7750fe5ffb1042f7cbe5dbb6403869/crc32c-2.7.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ba110df60c64c8e2d77a9425b982a520ccdb7abe42f06604f4d98a45bb1fff62", size = 35374, upload-time = "2024-09-24T06:18:46.304Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/0d/3e797d1ed92d357a6a4c5b41cea15a538b27a8fdf18c7863747eb50b73ad/crc32c-2.7.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c277f9d16a3283e064d54854af0976b72abaa89824955579b2b3f37444f89aae", size = 54641, upload-time = "2024-09-24T06:18:47.207Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/d3/4ddeef755caaa75680c559562b6c71f5910fee4c4f3a2eb5ea8b57f0e48c/crc32c-2.7.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:881af0478a01331244e27197356929edbdeaef6a9f81b5c6bacfea18d2139289", size = 52338, upload-time = "2024-09-24T06:18:49.31Z" },
-    { url = "https://files.pythonhosted.org/packages/01/cf/32f019be5de9f6e180926a50ee5f08648e686c7d9a59f2c5d0806a77b1c7/crc32c-2.7.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:724d5ff4d29ff093a983ae656be3307093706d850ea2a233bf29fcacc335d945", size = 53447, upload-time = "2024-09-24T06:18:50.296Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/8b/92f3f62f3bafe8f7ab4af7bfb7246dc683fd11ec0d6dfb73f91e09079f69/crc32c-2.7.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:b2416c4d88696ac322632555c0f81ab35e15f154bc96055da6cf110d642dbc10", size = 54484, upload-time = "2024-09-24T06:18:51.311Z" },
-    { url = "https://files.pythonhosted.org/packages/98/b2/113a50f8781f76af5ac65ffdb907e72bddbe974de8e02247f0d58bc48040/crc32c-2.7.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:60254251b88ec9b9795215f0f9ec015a6b5eef8b2c5fba1267c672d83c78fc02", size = 52703, upload-time = "2024-09-24T06:18:52.488Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/6c/309229e9acda8cf36a8ff4061d70b54d905f79b7037e16883ce6590a24ab/crc32c-2.7.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:edefc0e46f3c37372183f70338e5bdee42f6789b62fcd36ec53aa933e9dfbeaf", size = 53367, upload-time = "2024-09-24T06:18:53.49Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/2a/6c6324d920396e1bd9f3efbe8753da071be0ca52bd22d6c82d446b8d6975/crc32c-2.7.1-cp313-cp313-win32.whl", hash = "sha256:813af8111218970fe2adb833c5e5239f091b9c9e76f03b4dd91aaba86e99b499", size = 38377, upload-time = "2024-09-24T06:18:54.487Z" },
-    { url = "https://files.pythonhosted.org/packages/db/a0/f01ccfab538db07ef3f6b4ede46357ff147a81dd4f3c59ca6a34c791a549/crc32c-2.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:7d9ede7be8e4ec1c9e90aaf6884decbeef10e3473e6ddac032706d710cab5888", size = 39803, upload-time = "2024-09-24T06:18:55.419Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/80/61dcae7568b33acfde70c9d651c7d891c0c578c39cc049107c1cf61f1367/crc32c-2.7.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:db9ac92294284b22521356715784b91cc9094eee42a5282ab281b872510d1831", size = 49386, upload-time = "2024-09-24T06:18:56.813Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/f1/80f17c089799ab2b4c247443bdd101d6ceda30c46d7f193e16b5ca29c5a0/crc32c-2.7.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:8fcd7f2f29a30dc92af64a9ee3d38bde0c82bd20ad939999427aac94bbd87373", size = 36937, upload-time = "2024-09-24T06:18:57.77Z" },
-    { url = "https://files.pythonhosted.org/packages/63/42/5fcfc71a3de493d920fd2590843762a2749981ea56b802b380e5df82309d/crc32c-2.7.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5c056ef043393085523e149276a7ce0cb534b872e04f3e20d74d9a94a75c0ad7", size = 35292, upload-time = "2024-09-24T06:18:58.676Z" },
-    { url = "https://files.pythonhosted.org/packages/03/de/fef962e898a953558fe1c55141644553e84ef4190693a31244c59a0856c7/crc32c-2.7.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:03a92551a343702629af91f78d205801219692b6909f8fa126b830e332bfb0e0", size = 54223, upload-time = "2024-09-24T06:18:59.675Z" },
-    { url = "https://files.pythonhosted.org/packages/21/14/fceca1a6f45c0a1814fe8602a65657b75c27425162445925ba87438cad6b/crc32c-2.7.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fb9424ec1a8ca54763155a703e763bcede82e6569fe94762614bb2de1412d4e1", size = 51588, upload-time = "2024-09-24T06:19:00.938Z" },
-    { url = "https://files.pythonhosted.org/packages/13/3b/13d40a7dfbf9ef05c84a0da45544ee72080dca4ce090679e5105689984bd/crc32c-2.7.1-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:88732070f6175530db04e0bb36880ac45c33d49f8ac43fa0e50cfb1830049d23", size = 52678, upload-time = "2024-09-24T06:19:02.661Z" },
-    { url = "https://files.pythonhosted.org/packages/36/09/65ffc4fb9fa60ff6714eeb50a92284a4525e5943f0b040b572c0c76368c1/crc32c-2.7.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:57a20dfc27995f568f64775eea2bbb58ae269f1a1144561df5e4a4955f79db32", size = 53847, upload-time = "2024-09-24T06:19:03.705Z" },
-    { url = "https://files.pythonhosted.org/packages/24/71/938e926085b7288da052db7c84416f3ce25e71baf7ab5b63824c7bcb6f22/crc32c-2.7.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:f7186d098bfd2cff25eac6880b7c7ad80431b90610036131c1c7dd0eab42a332", size = 51860, upload-time = "2024-09-24T06:19:04.726Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/d8/4526d5380189d6f2fa27256c204100f30214fe402f47cf6e9fb9a91ab890/crc32c-2.7.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:55a77e29a265418fa34bef15bd0f2c60afae5348988aaf35ed163b4bbf93cf37", size = 52508, upload-time = "2024-09-24T06:19:05.731Z" },
-    { url = "https://files.pythonhosted.org/packages/19/30/15f7e35176488b77e5b88751947d321d603fccac273099ace27c7b2d50a6/crc32c-2.7.1-cp313-cp313t-win32.whl", hash = "sha256:ae38a4b6aa361595d81cab441405fbee905c72273e80a1c010fb878ae77ac769", size = 38319, upload-time = "2024-09-24T06:19:07.233Z" },
-    { url = "https://files.pythonhosted.org/packages/19/c4/0b3eee04dac195f4730d102d7a9fbea894ae7a32ce075f84336df96a385d/crc32c-2.7.1-cp313-cp313t-win_amd64.whl", hash = "sha256:eee2a43b663feb6c79a6c1c6e5eae339c2b72cfac31ee54ec0209fa736cf7ee5", size = 39781, upload-time = "2024-09-24T06:19:08.182Z" },
-]
-
-[[package]]
 name = "dask"
 version = "2025.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -322,6 +276,18 @@ array = [
 ]
 
 [[package]]
+name = "deprecated"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.3.9"
 source = { registry = "https://pypi.org/simple" }
@@ -331,15 +297,12 @@ wheels = [
 ]
 
 [[package]]
-name = "donfig"
-version = "0.8.1.post1"
+name = "fasteners"
+version = "0.20"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyyaml" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/25/71/80cc718ff6d7abfbabacb1f57aaa42e9c1552bfdd01e64ddd704e4a03638/donfig-0.8.1.post1.tar.gz", hash = "sha256:3bef3413a4c1c601b585e8d297256d0c1470ea012afa6e8461dc28bfb7c23f52", size = 19506, upload-time = "2024-05-23T14:14:31.513Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/18/7881a99ba5244bfc82f06017316ffe93217dbbbcfa52b887caa1d4f2a6d3/fasteners-0.20.tar.gz", hash = "sha256:55dce8792a41b56f727ba6e123fcaee77fd87e638a6863cec00007bfea84c8d8", size = 25087, upload-time = "2025-08-11T10:19:37.785Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl", hash = "sha256:2a3175ce74a06109ff9307d90a230f81215cbac9a751f4d1c6194644b8204f9d", size = 21592, upload-time = "2024-05-23T14:13:55.283Z" },
+    { url = "https://files.pythonhosted.org/packages/51/ac/e5d886f892666d2d1e5cb8c1a41146e1d79ae8896477b1153a21711d3b44/fasteners-0.20-py3-none-any.whl", hash = "sha256:9422c40d1e350e4259f509fb2e608d6bc43c0136f79a00db1b49046029d0b3b7", size = 18702, upload-time = "2025-08-11T10:19:35.716Z" },
 ]
 
 [[package]]
@@ -684,34 +647,26 @@ wheels = [
 
 [[package]]
 name = "numcodecs"
-version = "0.16.1"
+version = "0.15.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "deprecated" },
     { name = "numpy" },
-    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/00/35/49da850ce5371da3930d099da364a73ce9ae4fc64075e521674b48f4804d/numcodecs-0.16.1.tar.gz", hash = "sha256:c47f20d656454568c6b4697ce02081e6bbb512f198738c6a56fafe8029c97fb1", size = 6268134, upload-time = "2025-05-22T13:33:04.098Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/fc/bb532969eb8236984ba65e4f0079a7da885b8ac0ce1f0835decbb3938a62/numcodecs-0.15.1.tar.gz", hash = "sha256:eeed77e4d6636641a2cc605fbc6078c7a8f2cc40f3dfa2b3f61e52e6091b04ff", size = 6267275, upload-time = "2025-02-10T10:23:33.254Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/82/8d6ca1166dc9b020f383073c1c604e004f0495d243647a83e5d5fff2b7ad/numcodecs-0.16.1-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:5348a25aefbce37ea7c00c3363d36176155233c95597e5905a932e9620df960d", size = 1623980, upload-time = "2025-05-22T13:32:37.718Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/4e/11258b7945c6cd3579f16228c803a13291d16ef7ef46f9551008090b6763/numcodecs-0.16.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2058b0a985470809c720d2457758b61e6c9495a49d5f20dfac9b5ebabd8848eb", size = 1153826, upload-time = "2025-05-22T13:32:39.737Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/24/4099ccb29754fc1d2e55dbd9b540f58a24cab6e844dc996e37812c3fb79d/numcodecs-0.16.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b216b6d7bc207b85d41fddbc25b09fd00d76e265454db6e3fb09d5da0216397", size = 8263684, upload-time = "2025-05-22T13:32:41.252Z" },
-    { url = "https://files.pythonhosted.org/packages/04/e3/816a82b984dd7fb7a0afadd16842260ccfee23cc5edbda48a92649ee161b/numcodecs-0.16.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2308d56c4f84a5b942f8668b4adedd3d9cdd6a22e6e6e20768ec356c77050f38", size = 8788927, upload-time = "2025-05-22T13:32:42.905Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/54/dbea8b17928670412db0efb20efc087b30c2a67b84b1605fa8a136e482af/numcodecs-0.16.1-cp311-cp311-win_amd64.whl", hash = "sha256:acd8d68b4b815e62cb91e6064a53dac51ee99849350784ee16dd52cdbb4bc70f", size = 790259, upload-time = "2025-05-22T13:32:45.398Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/ee/e2a903c88fed347dc74c70bbd7a8dab9aa22bb0dac68c5bc6393c2e9373b/numcodecs-0.16.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:1abe0651ecb6f207656ebfc802effa55c4ae3136cf172c295a067749a2699122", size = 1663434, upload-time = "2025-05-22T13:32:47.26Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/f0/37819d4f6896b1ac43a164ffd3ab99d7cbf63bf63cb375fef97aedaef4f0/numcodecs-0.16.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:abb39b7102d0816c8563669cdddca40392d34d0cbf31e3e996706b244586a458", size = 1150402, upload-time = "2025-05-22T13:32:48.574Z" },
-    { url = "https://files.pythonhosted.org/packages/60/3c/5059a29750305b80b7428b1e6695878dea9ea3b537d7fba57875e4bbc2c7/numcodecs-0.16.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3359a951f8b23317f12736a7ad1e7375ec3d735465f92049c76d032ebca4c40", size = 8237455, upload-time = "2025-05-22T13:32:50.052Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/f5/515f98d659ab0cbe3738da153eddae22186fd38f05a808511e10f04cf679/numcodecs-0.16.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:82cc70592ec18060786b1bfa0da23afd2a7807d7975d766e626954d6628ec609", size = 8770711, upload-time = "2025-05-22T13:32:52.198Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/3a/9fc6104f888af11bad804ebd32dffe0bcb83337f4525b4fe5b379942fefd/numcodecs-0.16.1-cp312-cp312-win_amd64.whl", hash = "sha256:4b48ddc8a7d132b7808bc53eb2705342de5c1e39289d725f988bd143c0fd86df", size = 788701, upload-time = "2025-05-22T13:32:54.28Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/1e/73ffb1074f03d52cb1c4f4deaba26a2008ca45262f3622ed26dbec7a7362/numcodecs-0.16.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2ad8ee940315f59188accfc3f2d39726a4ca0d76b49bf8d0018e121f01c49028", size = 1659453, upload-time = "2025-05-22T13:32:55.558Z" },
-    { url = "https://files.pythonhosted.org/packages/42/72/5affb1ce92b7a6becee17921de7c6b521a48fa61fc3d36d9f1eea2cf83f5/numcodecs-0.16.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:179ca7bf3525a0f7379df7767d87dd495253de44597cb7e511198b28b09da633", size = 1143932, upload-time = "2025-05-22T13:32:56.908Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/f1/b092679d84c67c6ed62e4df5781d89bbb089f24a0df4187cbab9db51cf6b/numcodecs-0.16.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e2babbb50bf348ae982818d5560af330eab0dcd925fb0e49509785ad57d11db", size = 8187716, upload-time = "2025-05-22T13:32:58.421Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/e8/86e7741adb43261aff409b53c53c8bac2797bfca055d64dd65dc731d5141/numcodecs-0.16.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a4b29d8d3284b72bfad4fb83d672a17f497ae86ee1ef8087bac7222b620d3d91", size = 8728650, upload-time = "2025-05-22T13:33:00.337Z" },
-    { url = "https://files.pythonhosted.org/packages/21/03/87c5c217232aa3515d350728c6dcefca252fa582246100ef68a51fbda456/numcodecs-0.16.1-cp313-cp313-win_amd64.whl", hash = "sha256:06489635f43e1a959aea73cb830d78cf3adb07ac5f34daccb92091e4d9ac6b07", size = 785553, upload-time = "2025-05-22T13:33:02.587Z" },
-]
-
-[package.optional-dependencies]
-crc32c = [
-    { name = "crc32c" },
+    { url = "https://files.pythonhosted.org/packages/e4/fc/410f1cacaef0931f5daf06813b1b8a2442f7418ee284ec73fe5e830dca48/numcodecs-0.15.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:698f1d59511488b8fe215fadc1e679a4c70d894de2cca6d8bf2ab770eed34dfd", size = 1649501, upload-time = "2025-02-10T10:23:01.828Z" },
+    { url = "https://files.pythonhosted.org/packages/85/29/dff62fae04323035912c419a82dc9624fad7d08541dbfcd9ab78a3a40074/numcodecs-0.15.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:bef8c8e64fab76677324a07672b10c31861775d03fc63ed5012ca384144e4bb9", size = 1187306, upload-time = "2025-02-10T10:23:04.569Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/a8/908a226632ffabf19caf8c99f1b2898f2f22aac02795a6fe9d018fd6d9dd/numcodecs-0.15.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cdfaef9f5f2ed8f65858db801f1953f1007c9613ee490a1c56233cd78b505ed5", size = 8891971, upload-time = "2025-02-10T10:23:07.689Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/e8/058aac43e1300d588e99b2d0d5b771c8a43fa92ce9c9517da596869fc146/numcodecs-0.15.1-cp311-cp311-win_amd64.whl", hash = "sha256:e2547fa3a7ffc9399cfd2936aecb620a3db285f2630c86c8a678e477741a4b3c", size = 840035, upload-time = "2025-02-10T10:23:10.761Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/7e/f12fc32d3beedc6a8f1ec69ea0ba72e93cb99c0350feed2cff5d04679bc3/numcodecs-0.15.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b0a9d9cd29a0088220682dda4a9898321f7813ff7802be2bbb545f6e3d2f10ff", size = 1691889, upload-time = "2025-02-10T10:23:12.934Z" },
+    { url = "https://files.pythonhosted.org/packages/81/38/88e40d40288b73c3b3a390ed5614a34b0661d00255bdd4cfb91c32101364/numcodecs-0.15.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a34f0fe5e5f3b837bbedbeb98794a6d4a12eeeef8d4697b523905837900b5e1c", size = 1189149, upload-time = "2025-02-10T10:23:15.803Z" },
+    { url = "https://files.pythonhosted.org/packages/28/7d/7527d9180bc76011d6163c848c9cf02cd28a623c2c66cf543e1e86de7c5e/numcodecs-0.15.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c3a09e22140f2c691f7df26303ff8fa2dadcf26d7d0828398c0bc09b69e5efa3", size = 8879163, upload-time = "2025-02-10T10:23:18.582Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/bc/b6c3cde91c754860a3467a8c058dcf0b1a5ca14d82b1c5397c700cf8b1eb/numcodecs-0.15.1-cp312-cp312-win_amd64.whl", hash = "sha256:daed6066ffcf40082da847d318b5ab6123d69ceb433ba603cb87c323a541a8bc", size = 836785, upload-time = "2025-02-10T10:23:22.314Z" },
+    { url = "https://files.pythonhosted.org/packages/78/57/acbc54b3419e5be65015e47177c76c0a73e037fd3ae2cde5808169194d4d/numcodecs-0.15.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e3d82b70500cf61e8d115faa0d0a76be6ecdc24a16477ee3279d711699ad85f3", size = 1688220, upload-time = "2025-02-10T10:23:23.79Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/56/9863fa6dc679f40a31bea5e9713ee5507a31dcd3ee82ea4b1a9268ce52e8/numcodecs-0.15.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1d471a1829ce52d3f365053a2bd1379e32e369517557c4027ddf5ac0d99c591e", size = 1180294, upload-time = "2025-02-10T10:23:25.533Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/91/d96999b41e3146b6c0ce6bddc5ad85803cb4d743c95394562c2a4bb8cded/numcodecs-0.15.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1dfdea4a67108205edfce99c1cb6cd621343bc7abb7e16a041c966776920e7de", size = 8834323, upload-time = "2025-02-10T10:23:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/32/233e5ede6568bdb044e6f99aaa9fa39827ff3109c6487fc137315f733586/numcodecs-0.15.1-cp313-cp313-win_amd64.whl", hash = "sha256:a4f7bdb26f1b34423cb56d48e75821223be38040907c9b5954eeb7463e7eb03c", size = 831955, upload-time = "2025-02-10T10:23:30.601Z" },
 ]
 
 [[package]]
@@ -972,7 +927,7 @@ requires-dist = [
     { name = "transformers", specifier = ">=4.20.0" },
     { name = "typer", specifier = ">=0.9.0" },
     { name = "wandb", specifier = ">=0.21.0" },
-    { name = "zarr", specifier = ">=2.12.0" },
+    { name = "zarr", specifier = ">=2.12.0,<3" },
 ]
 provides-extras = ["dev"]
 
@@ -1766,19 +1721,93 @@ wheels = [
 ]
 
 [[package]]
+name = "wrapt"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/9f/06263fcd8ad6c405f05a3905fd7a84dd3176eb5ad46e44bccc0cd16348bb/wrapt-2.2.1.tar.gz", hash = "sha256:6744f504375775d7609c82c8d3d94af1c9a6f05586984536905908ba905277b9", size = 127620, upload-time = "2026-05-22T14:49:43.056Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/ac/4370bde262c0e633e6c4f0e56d55095710024cf9a5cecc20c59a10de483c/wrapt-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:dd57607acc85678925940bd5df0385ff8332083a32fa8d7a43f8767f4997263c", size = 80321, upload-time = "2026-05-22T14:47:43.996Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/79/b8ff3a61e71babf58a8cf4c0d63358e8bad383e15bf7f35e62d2f6b6e4a4/wrapt-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1ae574d65c9fa8e86f64f6a7c2668f9fcd507b183e0e577619f504b883cb0a6c", size = 81216, upload-time = "2026-05-22T14:47:45.243Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/fd/c0cac1f77c9c4f6fe58a920ca632ce379bb8be928720e11e8d73de28a5e9/wrapt-2.2.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9a04c28c10ba7fd12842b109d2edb0678872a2fe65277ca4ff06a0d61edee245", size = 159208, upload-time = "2026-05-22T14:47:47.176Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/4f/744132a7b2fbefa6b81118ec5942eca5fc2e9a129f9055a0c5e46885a549/wrapt-2.2.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3e2f02472a1cbbf3884b365714a810b5947134a95ad6952b554cb8cce9d492b0", size = 160322, upload-time = "2026-05-22T14:47:49.04Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/95/b7cd9a22a06cf93e6482904ee6afc956248983553593fd1009296d1b3b31/wrapt-2.2.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ac2745950b2bff80219c15ebf2fa9d8427eba7e249739f97e55c9d169e47e9e1", size = 153243, upload-time = "2026-05-22T14:47:50.386Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/4a/eb79423192015f46f0db2872e7e04a3dde8d359b83411e8959e7c9287eaa/wrapt-2.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:67a97e5b6c457f0cd3cfc19ebb2d84463e60c3ece754cc831e4281a3ca29bb18", size = 159231, upload-time = "2026-05-22T14:47:51.753Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/dc/435015b58ce33c6fc4104158fa91ddb0e809ab03a5751fb7465d1d461456/wrapt-2.2.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:c803a3d331796255af51ba2c79ed0ac8275865b516c09e61f248d1e7aff31ce9", size = 152351, upload-time = "2026-05-22T14:47:53.214Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ac/5d203f98df8fd136b95c5227139aea02d34505e18baf812d0c005df61963/wrapt-2.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9b984d1eb252145d6302c1dbd5e87fc6d404d45531447c84eadec04bf1fcb027", size = 158347, upload-time = "2026-05-22T14:47:54.982Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2f/a92427dbdc74e54c1674abbed27e61b2cb5e7a94441b8c1270c70671d928/wrapt-2.2.1-cp311-cp311-win32.whl", hash = "sha256:8a983a603a18c8708f024f7f6991b2e66159219abbf894634c5056243c55f3cd", size = 77562, upload-time = "2026-05-22T14:47:56.275Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/56/987b9c13b3e1c1a3c6de71284076f996b79caec90e75a87c044a40c23db9/wrapt-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:9c210a6994b21aa9b29e81c8d11560e8fdab54c117e9cff37870d0a27bde1343", size = 80616, upload-time = "2026-05-22T14:47:57.854Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/25/d01f560888d99d94a959c85533de349ce68d71ace3f2591d6ea8f632cfed/wrapt-2.2.1-cp311-cp311-win_arm64.whl", hash = "sha256:401229e9d63ca09f9b8891ecf83798d26c11bbb445d11ed9f1836b6d4585b38a", size = 79025, upload-time = "2026-05-22T14:47:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/89/0c/bfae7b9401583b6d05938cd16dedc43857d96da2f8a3d50d78cc515bf6ff/wrapt-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3ffad790d9d11d8ecf9f17c4bb671a5b4089e4d8b575c46c5129597f41f836b0", size = 81021, upload-time = "2026-05-22T14:48:00.313Z" },
+    { url = "https://files.pythonhosted.org/packages/26/58/80f6a6599f933f4caecc1cb3ee88a04faf81e8b9bddbd6109c688dd63e0f/wrapt-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:628f5220c7a904d5fc78f7075c8d7871433eb6d035c94728a22fdf85f193d2a8", size = 81692, upload-time = "2026-05-22T14:48:01.49Z" },
+    { url = "https://files.pythonhosted.org/packages/17/93/fb357cc7847c58a8ae790be718903afa81a28d23e642c843dc4129e8a0b2/wrapt-2.2.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:61acce4257a9883669703c525447c5b4c392edf0f987ae77ec32668440158f0e", size = 169364, upload-time = "2026-05-22T14:48:02.791Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/0b/76b601ee309a8bd556af0eecb184394c20b3c49aa9c8e085aa1ffacc2568/wrapt-2.2.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:727ab4244622cd6ad2390f322642090c877d2e83a608d2653a7643ae5368d926", size = 171079, upload-time = "2026-05-22T14:48:04.22Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/87/ee3f32d5658e3e26d3e0e457922b47a36dd3bfbdfee7f97bb3e802344a66/wrapt-2.2.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:03df9ebed4c73ab93fa8c07e3d41d818dfca1852b15731a3de59457b27814624", size = 160205, upload-time = "2026-05-22T14:48:05.553Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/d0/ae2fd64277a67f5d7bffcf2d05eea1e476263fb2a072baf0b0129ab85984/wrapt-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0d9ff006f420b2ec8296aa56ade43ea7da3e997e85769f0aafc5e0661aacb710", size = 168922, upload-time = "2026-05-22T14:48:07.132Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f3/2d541a060c5bbafb9400bca4917e4d78bfd1f239f404782c86831a8f6b29/wrapt-2.2.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:844c858fc3bb7eacc0ba8efa904935d16aac6a4470948ad1e7e55c9f5a2a665f", size = 158388, upload-time = "2026-05-22T14:48:08.629Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/68/8d92c8800c57e93cb116ae9e9d6cbafc34fade5ee9f9107b6f203fb4dc35/wrapt-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:87bacdaf225117a342a20d9c03438d701c02112f6e3f351ce9b7f32354f14797", size = 167682, upload-time = "2026-05-22T14:48:10.042Z" },
+    { url = "https://files.pythonhosted.org/packages/30/72/83ea3790ea352439442349388e29ff07b76e0686265f9088bbb505d1608d/wrapt-2.2.1-cp312-cp312-win32.whl", hash = "sha256:2f8c90c8afde51969487be4e1343ae049b268854877d415c2510baf833775052", size = 77857, upload-time = "2026-05-22T14:48:11.782Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/cb/99450668dd3502d62a54a1c8aa56e44f34cb8c1261b381cfe2e7926c3b75/wrapt-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:6ce32763ac31ce94fe9aada947e479b1975012bff166da409b4b9e4e376cf7e5", size = 80825, upload-time = "2026-05-22T14:48:13.046Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/3a/87512881be64e743f9ee4c66f4cbe8e884974bef2a5989af71f999653ac7/wrapt-2.2.1-cp312-cp312-win_arm64.whl", hash = "sha256:8d1b4d0e0c2119587a31f5c029abd547e0c81d93b89d394566fe1588659eb579", size = 79087, upload-time = "2026-05-22T14:48:14.323Z" },
+    { url = "https://files.pythonhosted.org/packages/88/d1/a1b08f8f4fac8cbb156fa51cf64ee2c7f7f74f9875ba3cf70b3c58368694/wrapt-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d2beb1c7cab10603aecdc42f8edd6ff013f9a32e4543474e38e6b77ce9975aeb", size = 80831, upload-time = "2026-05-22T14:48:15.598Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ce/57890814991446a845e09b3445ce8b694f27eb0577004f2c2a36a9772ed4/wrapt-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e0cb7e4dd71f4c32e5e84843cd3c4cd65dda034314004bbe1d7f99af2426ab80", size = 81375, upload-time = "2026-05-22T14:48:17.071Z" },
+    { url = "https://files.pythonhosted.org/packages/38/65/08d7a6c76ac4493bdb668205ee9c1de1bd5daca61717c3e9aa49b4c01499/wrapt-2.2.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95821352042722cd9f1108874579a47989d0a7e12a37d87d2fc4af20fd99ab8a", size = 167417, upload-time = "2026-05-22T14:48:18.303Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ce/f1ccbee7a1bfe5cdc6b3da6bab4b45713d628b9294da32a39f563d648140/wrapt-2.2.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:abd621552ede77c4c69be7fac44ba911225b0c812b6ba604e5964cf98085b474", size = 166948, upload-time = "2026-05-22T14:48:19.768Z" },
+    { url = "https://files.pythonhosted.org/packages/86/2a/f85d48d1cd4869aee6704028d257d740a47c1c467b457ce396b4b5b55d07/wrapt-2.2.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e3677c7146ce694874941ba82b57092cc4875445aadf29d72807351023105143", size = 158148, upload-time = "2026-05-22T14:48:21.96Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/5c/93939ad11d4a12358ab1aab219a2ef5efa5612e0db6b9fc65af8af1a891b/wrapt-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9a5934eaea872e17936b5f45501eba5ab0bce9a74122e172b663d7c28c459c4a", size = 165905, upload-time = "2026-05-22T14:48:23.373Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/22/b8c2aa89862ff58605934d7abf4b70e6a5a1c33df96656f49035ccdf1c8a/wrapt-2.2.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f5b9daf6b629fce418e0cc3dd0436eac045188fa35deadb7a7f3941d5b8203f9", size = 156712, upload-time = "2026-05-22T14:48:24.767Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/bf00a7b02239c12bb02ddcc3c0b971bfcc36e578c5a44f1ccfef5b458545/wrapt-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f53ac9f3ef573326d009ed809beff4efcac6451931c2b8132586da4b9e53ff31", size = 166560, upload-time = "2026-05-22T14:48:26.83Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/93/6390ca9c5b787683cef588d04f57c8d41b9a2323b5597a65f18638c90ef2/wrapt-2.2.1-cp313-cp313-win32.whl", hash = "sha256:1ffa9cfd4bdb581539951b14ae661ff20ed0c3599b3e911a131ee0ec5ac11337", size = 77817, upload-time = "2026-05-22T14:48:28.221Z" },
+    { url = "https://files.pythonhosted.org/packages/97/73/ce10f0e71c0cfaa1a65faadb8efd4852028b3bb9ba28932b8889df769d38/wrapt-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:368eac1e20fd0bb03dd3cc42bf9887154c3861b60989389ccb5fac032617d215", size = 80736, upload-time = "2026-05-22T14:48:30.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/4c/89f4a6818fafbbd840330e4fa3873073e1bfc166133a64cac7f8fde7a5e3/wrapt-2.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:c754dafdf5aaf0b401b644a90a30046929a0dd1a536e0ff0ec959a59155d9c7f", size = 79099, upload-time = "2026-05-22T14:48:31.405Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/f2/9a8741c46f8c208ac0a45b25ba170bcb4fb72a2781d5fb97dbd7b6be73cb/wrapt-2.2.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ed928d0fda15fc0adc8d13305c8b3c0f2fba5b0669950c9e6d019d9162a3b3e8", size = 82802, upload-time = "2026-05-22T14:48:33.307Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/0d/e9c855716a3705eef1416456bdf062b60620726fdc59428ff670fc3c60dc/wrapt-2.2.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fafb4e739e43544d12cb4abd1605fd4683b6ca6a9ad682b7fd8f4d21973eafa8", size = 83329, upload-time = "2026-05-22T14:48:34.593Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/d6/a88f1c13112b7831adac75cea65d8310e0d696d570c8961844c90a57b865/wrapt-2.2.1-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:74d6a0c31472fe5d814917266b9f46495d7c61ed890af08b468acea92fb89a8d", size = 202937, upload-time = "2026-05-22T14:48:35.859Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/e29d54aef06a4d898a5b8a25589a0b3769bde454f922fad8f6f89fbfb650/wrapt-2.2.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab5be648d5a0b86b7438864f8df3c705a65cef35a2fd3e5561e3e203167e0f27", size = 209997, upload-time = "2026-05-22T14:48:38.153Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/91/e4454263516cf0e12640912fbca9a83654e424f0a6ddb79f5cd7ce14bf33/wrapt-2.2.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9d8f204c8e3a8bf9ece17e0a83d137fd807440977f8a5e762d59306795011440", size = 194856, upload-time = "2026-05-22T14:48:39.69Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d0/fe0ee202286afdf4a7f77dd29f195703145764d572aec209c5086e57d924/wrapt-2.2.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d047f6498c973874ba08ac3f97c69a2c4b2211c8de6f4c205f75cb1c9522596e", size = 205654, upload-time = "2026-05-22T14:48:43.456Z" },
+    { url = "https://files.pythonhosted.org/packages/23/b6/87d860dfc6460c246af70b1fd5c8b76df77571b42a493459423ded94fd7d/wrapt-2.2.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:7a4fdb9326aab4a5a477a1640e5ad786a8495901009d7e7b038371edd23a9d2b", size = 192206, upload-time = "2026-05-22T14:48:44.858Z" },
+    { url = "https://files.pythonhosted.org/packages/df/46/3eea8cde077d985f239a38c0257087b8064fd9ee9b1a99e282d2c86da4ef/wrapt-2.2.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c8cc5094b08abeae52da9c73c8a32003623be691a5193df2f4e3eac3d557c394", size = 198428, upload-time = "2026-05-22T14:48:46.319Z" },
+    { url = "https://files.pythonhosted.org/packages/18/dc/b927ee9c7fc67adc3a5658f246a0d275425eb840ba36e7b702e70f18bde8/wrapt-2.2.1-cp313-cp313t-win32.whl", hash = "sha256:9907a4402ab6db12b7077a0ea5d7a4d028ecb22c8eee2b53527080d347cd1562", size = 79448, upload-time = "2026-05-22T14:48:47.901Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/b3/fd30b473fe498c70e6b9a5f328b8d3fbaf1b8c3c481465f59724bba8eb70/wrapt-2.2.1-cp313-cp313t-win_amd64.whl", hash = "sha256:5590d63f5243251641cf543009b4c9314a79d0598fdb8a8e4cfc918494536c53", size = 83021, upload-time = "2026-05-22T14:48:49.201Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f3/96c39153a8737a6e9aa85adef254ac4195bea3f2d24efc60472ccc3c9e2e/wrapt-2.2.1-cp313-cp313t-win_arm64.whl", hash = "sha256:c318a64b53d97b841d7b5e637517e50a27be64bc695128422953d4b21710954e", size = 80295, upload-time = "2026-05-22T14:48:50.479Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/a3/11d7f34ebbf3231bc907a3e6d5ee051b14d034c1bc7b65a97d5cc00516df/wrapt-2.2.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6f56a647e4eaf5f0ca40330fb070f566bdf9f7b0db89a1af20d71c28dcd7a0ab", size = 80879, upload-time = "2026-05-22T14:48:51.802Z" },
+    { url = "https://files.pythonhosted.org/packages/13/3c/b74cfd984cef560b900fb1a727af20352d89e1f06bf2e1114dd3f00f5f5a/wrapt-2.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:64b7deeda4b70408e382328d8bbe52a256fe9bc63ae3db86d804608367e5422c", size = 81462, upload-time = "2026-05-22T14:48:53.18Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a3/7c8f704b8dc07dfe0a5d01c2edbfd88317aa8e5e3fa7c743eb7a085ae767/wrapt-2.2.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b9cf53ba90717db2e292401de290776c498d4bbfb0d4a559ca2895db8b9dcb5c", size = 167251, upload-time = "2026-05-22T14:48:54.562Z" },
+    { url = "https://files.pythonhosted.org/packages/80/85/a34d1888d97247da6c2ff6118c3a721c73ed8cc4dd198c00208bb73b6f80/wrapt-2.2.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cf3638274ab9d9b724c9baa0b4c04e132cd6faefb78b4dd3dd1a02a4bdaad41e", size = 166316, upload-time = "2026-05-22T14:48:56.065Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d7/72ffaeb01eebc704afe3fb99e840480f4bda45f0fa66e3381b6a39251c8f/wrapt-2.2.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aed9658797d0b45d6c49adcfc6b41f66e6f2d0c6de3ec79e16cf4b1855df240f", size = 157952, upload-time = "2026-05-22T14:48:57.924Z" },
+    { url = "https://files.pythonhosted.org/packages/24/5b/36f5d6b024e4edfdd90b140742d11ebcf7836daf5c9daf326c55c24db412/wrapt-2.2.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1d676ee388bc42a04d56dd7deb5605244dac2e35cc2fadbb43c9fa25bbd93508", size = 166130, upload-time = "2026-05-22T14:48:59.384Z" },
+    { url = "https://files.pythonhosted.org/packages/81/06/9296d9e97bfdef5483dfcc859d57b095b257144b2bc5300ab521e06f4bc7/wrapt-2.2.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e395f7bc31851ef9b612050368cb446e9bc14cd7454b025018980349caf25ae5", size = 156604, upload-time = "2026-05-22T14:49:00.921Z" },
+    { url = "https://files.pythonhosted.org/packages/53/37/16953929ed6776175720e58fc966e779926d8d71e2c7b2273230590ca71f/wrapt-2.2.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5f1845c2a8cc1180ccccfa45785dd06f562730d19ef75be180334254012b6283", size = 166007, upload-time = "2026-05-22T14:49:02.332Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/73/20ee58c0612dae7c31131a7095345812ed2c7b389019e175f68cde34e5b4/wrapt-2.2.1-cp314-cp314-win32.whl", hash = "sha256:436addbc4bb4fc0a88c702577f51195d7d73683a7f3e0e5b253d8404d7847243", size = 78327, upload-time = "2026-05-22T14:49:03.722Z" },
+    { url = "https://files.pythonhosted.org/packages/22/b3/ef7c3295d02e0448a71c639a36a057f46d524d057c9486291a7a3039e65c/wrapt-2.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:50972a1d974ea07725a7f6b1cec5f8759008afd030a0024843ebe7d52de47f2b", size = 81144, upload-time = "2026-05-22T14:49:05.093Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/dc/7bdf336953f99f4ceb0a584bb8870e42c8f26f93ea10c87834dad62f1668/wrapt-2.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:1c9934ea5d92957e3cd0adbc0845539dccfd62710ebe16195a8c66c53954db36", size = 79569, upload-time = "2026-05-22T14:49:06.413Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6d/6dfae80150ff1919c356d1dd528f049bcdfaae29b4d284bc957e022caef4/wrapt-2.2.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:17de18fc12cea55b8a9587314cb830573e37fb33b247a7515696350863714188", size = 82892, upload-time = "2026-05-22T14:49:07.925Z" },
+    { url = "https://files.pythonhosted.org/packages/82/7b/4e34766a7d7804ffce9e71befe47e9b3225dc350c49c94493c4ab39fd3a5/wrapt-2.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a9dec1aca52dddde7df94818310fa2fe79739c8f385b2014c4cb1035f5508199", size = 83333, upload-time = "2026-05-22T14:49:09.257Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/57/0b34db3e8de44ccfece62d7b337abd1631dd810f5adc5f3db571727836b5/wrapt-2.2.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:69f2e9244542cb34dd59c7f073445b9e54ad9f3fce8d93606c368a1b499fc413", size = 202899, upload-time = "2026-05-22T14:49:10.572Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/45/ac0c459f154b99d92789a6cba7ca727185b83513b986f8ec7fe2aacddcbf/wrapt-2.2.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d83966dc7f4f45e8b97b5933685ac2e6e67fc0e19246ea314bceb9a8970c956", size = 209986, upload-time = "2026-05-22T14:49:12.229Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e4/77e37ff33ad018fa81ade52c25fa327b80b56f81d734279a63614fcb4cbc/wrapt-2.2.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:78b0aa6bfb7be8deed0ab23e7aa028cc5210c29bc2d32a04d52b50e517a7307e", size = 194893, upload-time = "2026-05-22T14:49:14.139Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/9d/7ea651d1ab032fc5fa222fbec91d0f8a1397f6ae04ebb93fa7219aa921d7/wrapt-2.2.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:05d5cb74d1b232ec8cfa130a8f900708699ff2491d97b8f85a4cdc5996294b85", size = 205636, upload-time = "2026-05-22T14:49:15.714Z" },
+    { url = "https://files.pythonhosted.org/packages/09/af/8e88031a701275b9085c54e64bc88c0b1cd55c77eadd400691c371cd76c4/wrapt-2.2.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f6518b94edb9150452e9aba08027d4cc293433753ec1fbefb4629a21cbc74181", size = 192267, upload-time = "2026-05-22T14:49:17.283Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/a8/e657ca876b06710194f243d81c4b0896ade646e244bdbec2d87c8c56a8bd/wrapt-2.2.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ed55af48b3eb28f43228ca2306788892bcb629eb2b5c4876e2a3659872c2f17a", size = 198378, upload-time = "2026-05-22T14:49:18.785Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/59/822efe4ea722a3961331bfa35b7d90937790d2c20f0616de1997ccc3aebd/wrapt-2.2.1-cp314-cp314t-win32.whl", hash = "sha256:2e08688ab16525897da6589d56d0aebaf417bbe91c2d8e3b96203b1efa596e85", size = 80226, upload-time = "2026-05-22T14:49:20.264Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/31/2a7dc5f6abb2fca0b6e1610e120419f603650aceb4f1d3ac4cae0354e162/wrapt-2.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:fd0135d34387f5fd087d9be368ea77ea89cf2451dc1cd1c622d35021bcb3ab50", size = 83835, upload-time = "2026-05-22T14:49:21.634Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/c0/782b86e28d1ceebeb74cccea12d2cd3d2ba0bd68e3dec20b1bc5873f6127/wrapt-2.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:f70db64e8266d7c45d3b735f2e08eeb434b5e03da9a479ae42b2e2e486a21a00", size = 80722, upload-time = "2026-05-22T14:49:23.59Z" },
+    { url = "https://files.pythonhosted.org/packages/53/46/29ac9daf11a86c22a8c38cd9236c62928ccae83f7ceb06bd3b0467cf9d05/wrapt-2.2.1-py3-none-any.whl", hash = "sha256:3aafea2975caef8ca49400640dde02cc7426e798f24870ed01f490bc3cffd32f", size = 61000, upload-time = "2026-05-22T14:49:41.593Z" },
+]
+
+[[package]]
 name = "zarr"
-version = "3.0.8"
+version = "2.18.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "donfig" },
-    { name = "numcodecs", extra = ["crc32c"] },
+    { name = "asciitree" },
+    { name = "fasteners", marker = "sys_platform != 'emscripten'" },
+    { name = "numcodecs" },
     { name = "numpy" },
-    { name = "packaging" },
-    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/60/9652fd0536fbaca8d08cbc1a5572c52e0ce01773297df75da8bb47e45907/zarr-3.0.8.tar.gz", hash = "sha256:88505d095af899a88ae8ac4db02f4650ef0801d2ff6f65b6d1f0a45dcf760a6d", size = 256825, upload-time = "2025-05-19T14:19:00.123Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/1d/01cf9e3ab2d85190278efc3fca9f68563de35ae30ee59e7640e3af98abe3/zarr-2.18.7.tar.gz", hash = "sha256:b2b8f66f14dac4af66b180d2338819981b981f70e196c9a66e6bfaa9e59572f5", size = 3604558, upload-time = "2025-04-09T07:59:28.482Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/3b/e20bdf84088c11f2c396d034506cbffadd53e024111c1aa4585c2aba1523/zarr-3.0.8-py3-none-any.whl", hash = "sha256:7f81e7aec086437d98882aa432209107114bd7f3a9f4958b2af9c6b5928a70a7", size = 205364, upload-time = "2025-05-19T14:18:58.789Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/d8/9ffd8c237b3559945bb52103cf0eed64ea098f7b7f573f8d2962ef27b4b2/zarr-2.18.7-py3-none-any.whl", hash = "sha256:ac3dc4033e9ae4e9d7b5e27c97ea3eaf1003cc0a07f010bd83d5134bf8c4b223", size = 211273, upload-time = "2025-04-09T07:59:27.039Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -10,20 +10,25 @@ resolution-markers = [
 
 [[package]]
 name = "anndata"
-version = "0.11.4"
+version = "0.12.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "array-api-compat" },
     { name = "h5py" },
+    { name = "legacy-api-wrap" },
     { name = "natsort" },
     { name = "numpy" },
     { name = "packaging" },
     { name = "pandas" },
     { name = "scipy" },
+    { name = "scverse-misc", version = "0.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "scverse-misc", version = "0.0.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "zarr", version = "3.1.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "zarr", version = "3.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/bb/895fa2e9f8cd6d1c058aa90759da715037d0f11e23713e692537555549d7/anndata-0.11.4.tar.gz", hash = "sha256:4ce08d09d2ccb5f37d32790363bbcc7fc1b79863842296ae4badfaf48c736e24", size = 541143, upload-time = "2025-03-26T11:38:54.566Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/e4/8cdf4d18c422e6c30edf512d599f9781fb458939d6317cc1e1e7940f2157/anndata-0.12.17.tar.gz", hash = "sha256:86608c28dc78d8a30c03fb3566caf6fa73d9c5aa7be53e4ed6b20888cc5e4337", size = 2257555, upload-time = "2026-06-16T12:30:15.608Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0a/4b/ab615fea52e34579d5c6c7dba86b4f9d7f3cdb6a170b348ec49f34cf4355/anndata-0.11.4-py3-none-any.whl", hash = "sha256:fefebb1480316dfa5a23924aa9f74781d447484421bb0c788b0b2ca5e3b339d2", size = 144472, upload-time = "2025-03-26T11:38:52.547Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/f6/bca233b8311dc2217d9d7c1687acdfa347f778f6f6eb622d8e5afa39f014/anndata-0.12.17-py3-none-any.whl", hash = "sha256:a19e48741a935752d11c9d2dc968ac0cdf3900e0c8c3413320fde84ab11dc9e6", size = 175991, upload-time = "2026-06-16T12:30:13.686Z" },
 ]
 
 [[package]]
@@ -49,12 +54,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/8d/bd/9fa5c7c5621698d56
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/b1/0542e0cab6f49f151a2d7a42400f84f706fc0b64e85dc1f56708b2e9fd37/array_api_compat-1.12.0-py3-none-any.whl", hash = "sha256:a0b4795b6944a9507fde54679f9350e2ad2b1e2acf4a2408a098cdc27f890a8b", size = 58156, upload-time = "2025-05-16T08:49:58.129Z" },
 ]
-
-[[package]]
-name = "asciitree"
-version = "0.3.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2d/6a/885bc91484e1aa8f618f6f0228d76d0e67000b0fdd6090673b777e311913/asciitree-0.3.3.tar.gz", hash = "sha256:4aa4b9b649f85e3fcb343363d97564aa1fb62e249677f2e18a96765145cc0f6e", size = 3951, upload-time = "2016-09-05T19:10:42.681Z" }
 
 [[package]]
 name = "autopep8"
@@ -297,12 +296,15 @@ wheels = [
 ]
 
 [[package]]
-name = "fasteners"
-version = "0.20"
+name = "donfig"
+version = "0.8.1.post1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2d/18/7881a99ba5244bfc82f06017316ffe93217dbbbcfa52b887caa1d4f2a6d3/fasteners-0.20.tar.gz", hash = "sha256:55dce8792a41b56f727ba6e123fcaee77fd87e638a6863cec00007bfea84c8d8", size = 25087, upload-time = "2025-08-11T10:19:37.785Z" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/71/80cc718ff6d7abfbabacb1f57aaa42e9c1552bfdd01e64ddd704e4a03638/donfig-0.8.1.post1.tar.gz", hash = "sha256:3bef3413a4c1c601b585e8d297256d0c1470ea012afa6e8461dc28bfb7c23f52", size = 19506, upload-time = "2024-05-23T14:14:31.513Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/ac/e5d886f892666d2d1e5cb8c1a41146e1d79ae8896477b1153a21711d3b44/fasteners-0.20-py3-none-any.whl", hash = "sha256:9422c40d1e350e4259f509fb2e608d6bc43c0136f79a00db1b49046029d0b3b7", size = 18702, upload-time = "2025-08-11T10:19:35.716Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl", hash = "sha256:2a3175ce74a06109ff9307d90a230f81215cbac9a751f4d1c6194644b8204f9d", size = 21592, upload-time = "2024-05-23T14:13:55.283Z" },
 ]
 
 [[package]]
@@ -359,6 +361,36 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c0/89/37df0b71473153574a5cdef8f242de422a0f5d26d7a9e231e6f169b4ad14/gitpython-3.1.44.tar.gz", hash = "sha256:c87e30b26253bf5418b01b0660f818967f3c503193838337fe5e573331249269", size = 214196, upload-time = "2025-01-02T07:32:43.59Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1d/9a/4114a9057db2f1462d5c8f8390ab7383925fe1ac012eaa42402ad65c2963/GitPython-3.1.44-py3-none-any.whl", hash = "sha256:9e0e10cda9bed1ee64bc9a6de50e7e38a9c9943241cd7f585f6df3ed28011110", size = 207599, upload-time = "2025-01-02T07:32:40.731Z" },
+]
+
+[[package]]
+name = "google-crc32c"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/41/4b9c02f99e4c5fb477122cd5437403b552873f014616ac1d19ac8221a58d/google_crc32c-1.8.0.tar.gz", hash = "sha256:a428e25fb7691024de47fecfbff7ff957214da51eddded0da0ae0e0f03a2cf79", size = 14192, upload-time = "2025-12-16T00:35:25.142Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/ef/21ccfaab3d5078d41efe8612e0ed0bfc9ce22475de074162a91a25f7980d/google_crc32c-1.8.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:014a7e68d623e9a4222d663931febc3033c5c7c9730785727de2a81f87d5bab8", size = 31298, upload-time = "2025-12-16T00:20:32.241Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b8/f8413d3f4b676136e965e764ceedec904fe38ae8de0cdc52a12d8eb1096e/google_crc32c-1.8.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:86cfc00fe45a0ac7359e5214a1704e51a99e757d0272554874f419f79838c5f7", size = 30872, upload-time = "2025-12-16T00:33:58.785Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/fd/33aa4ec62b290477181c55bb1c9302c9698c58c0ce9a6ab4874abc8b0d60/google_crc32c-1.8.0-cp311-cp311-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:19b40d637a54cb71e0829179f6cb41835f0fbd9e8eb60552152a8b52c36cbe15", size = 33243, upload-time = "2025-12-16T00:40:21.46Z" },
+    { url = "https://files.pythonhosted.org/packages/71/03/4820b3bd99c9653d1a5210cb32f9ba4da9681619b4d35b6a052432df4773/google_crc32c-1.8.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:17446feb05abddc187e5441a45971b8394ea4c1b6efd88ab0af393fd9e0a156a", size = 33608, upload-time = "2025-12-16T00:40:22.204Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/43/acf61476a11437bf9733fb2f70599b1ced11ec7ed9ea760fdd9a77d0c619/google_crc32c-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:71734788a88f551fbd6a97be9668a0020698e07b2bf5b3aa26a36c10cdfb27b2", size = 34439, upload-time = "2025-12-16T00:35:20.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/5f/7307325b1198b59324c0fa9807cafb551afb65e831699f2ce211ad5c8240/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:4b8286b659c1335172e39563ab0a768b8015e88e08329fa5321f774275fc3113", size = 31300, upload-time = "2025-12-16T00:21:56.723Z" },
+    { url = "https://files.pythonhosted.org/packages/21/8e/58c0d5d86e2220e6a37befe7e6a94dd2f6006044b1a33edf1ff6d9f7e319/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:2a3dc3318507de089c5384cc74d54318401410f82aa65b2d9cdde9d297aca7cb", size = 30867, upload-time = "2025-12-16T00:38:31.302Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a9/a780cc66f86335a6019f557a8aaca8fbb970728f0efd2430d15ff1beae0e/google_crc32c-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:14f87e04d613dfa218d6135e81b78272c3b904e2a7053b841481b38a7d901411", size = 33364, upload-time = "2025-12-16T00:40:22.96Z" },
+    { url = "https://files.pythonhosted.org/packages/21/3f/3457ea803db0198c9aaca2dd373750972ce28a26f00544b6b85088811939/google_crc32c-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb5c869c2923d56cb0c8e6bcdd73c009c36ae39b652dbe46a05eb4ef0ad01454", size = 33740, upload-time = "2025-12-16T00:40:23.96Z" },
+    { url = "https://files.pythonhosted.org/packages/df/c0/87c2073e0c72515bb8733d4eef7b21548e8d189f094b5dad20b0ecaf64f6/google_crc32c-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:3cc0c8912038065eafa603b238abf252e204accab2a704c63b9e14837a854962", size = 34437, upload-time = "2025-12-16T00:35:21.395Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/db/000f15b41724589b0e7bc24bc7a8967898d8d3bc8caf64c513d91ef1f6c0/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:3ebb04528e83b2634857f43f9bb8ef5b2bbe7f10f140daeb01b58f972d04736b", size = 31297, upload-time = "2025-12-16T00:23:20.709Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/8ebed0c39c53a7e838e2a486da8abb0e52de135f1b376ae2f0b160eb4c1a/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:450dc98429d3e33ed2926fc99ee81001928d63460f8538f21a5d6060912a8e27", size = 30867, upload-time = "2025-12-16T00:43:14.628Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/42/b468aec74a0354b34c8cbf748db20d6e350a68a2b0912e128cabee49806c/google_crc32c-1.8.0-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3b9776774b24ba76831609ffbabce8cdf6fa2bd5e9df37b594221c7e333a81fa", size = 33344, upload-time = "2025-12-16T00:40:24.742Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e8/b33784d6fc77fb5062a8a7854e43e1e618b87d5ddf610a88025e4de6226e/google_crc32c-1.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:89c17d53d75562edfff86679244830599ee0a48efc216200691de8b02ab6b2b8", size = 33694, upload-time = "2025-12-16T00:40:25.505Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b1/d3cbd4d988afb3d8e4db94ca953df429ed6db7282ed0e700d25e6c7bfc8d/google_crc32c-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:57a50a9035b75643996fbf224d6661e386c7162d1dfdab9bc4ca790947d1007f", size = 34435, upload-time = "2025-12-16T00:35:22.107Z" },
+    { url = "https://files.pythonhosted.org/packages/21/88/8ecf3c2b864a490b9e7010c84fd203ec8cf3b280651106a3a74dd1b0ca72/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:e6584b12cb06796d285d09e33f63309a09368b9d806a551d8036a4207ea43697", size = 31301, upload-time = "2025-12-16T00:24:48.527Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c6/f7ff6c11f5ca215d9f43d3629163727a272eabc356e5c9b2853df2bfe965/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:f4b51844ef67d6cf2e9425983274da75f18b1597bb2c998e1c0a0e8d46f8f651", size = 30868, upload-time = "2025-12-16T00:48:12.163Z" },
+    { url = "https://files.pythonhosted.org/packages/56/15/c25671c7aad70f8179d858c55a6ae8404902abe0cdcf32a29d581792b491/google_crc32c-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b0d1a7afc6e8e4635564ba8aa5c0548e3173e41b6384d7711a9123165f582de2", size = 33381, upload-time = "2025-12-16T00:40:26.268Z" },
+    { url = "https://files.pythonhosted.org/packages/42/fa/f50f51260d7b0ef5d4898af122d8a7ec5a84e2984f676f746445f783705f/google_crc32c-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8b3f68782f3cbd1bce027e48768293072813469af6a61a86f6bb4977a4380f21", size = 33734, upload-time = "2025-12-16T00:40:27.028Z" },
+    { url = "https://files.pythonhosted.org/packages/08/a5/7b059810934a09fb3ccb657e0843813c1fee1183d3bc2c8041800374aa2c/google_crc32c-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:d511b3153e7011a27ab6ee6bb3a5404a55b994dc1a7322c0b87b29606d9790e2", size = 34878, upload-time = "2025-12-16T00:35:23.142Z" },
+    { url = "https://files.pythonhosted.org/packages/52/c5/c171e4d8c44fec1422d801a6d2e5d7ddabd733eeda505c79730ee9607f07/google_crc32c-1.8.0-pp311-pypy311_pp73-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:87fa445064e7db928226b2e6f0d5304ab4cd0339e664a4e9a25029f384d9bb93", size = 28615, upload-time = "2025-12-16T00:40:29.298Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/97/7d75fe37a7a6ed171a2cf17117177e7aab7e6e0d115858741b41e9dd4254/google_crc32c-1.8.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f639065ea2042d5c034bf258a9f085eaa7af0cd250667c0635a3118e8f92c69c", size = 28800, upload-time = "2025-12-16T00:40:30.322Z" },
 ]
 
 [[package]]
@@ -479,6 +511,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "legacy-api-wrap"
+version = "1.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/49/f06f94048c8974205730d40beca879e43b6eee08efb0101cfb8623e60f41/legacy_api_wrap-1.5.tar.gz", hash = "sha256:b41ba6532f3ebfe3a897a35a7f97dec3be04b92a450f6c2bcf89f1b91c9cadf2", size = 11610, upload-time = "2025-11-03T13:21:12.437Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/5b/058db09c45ba58a7321bdf2294cae651b37d6fec68117265af90cde043b0/legacy_api_wrap-1.5-py3-none-any.whl", hash = "sha256:5a8ea50e3e3bcbcdec3447b77034fd0d32cb2cf4089db799238708e4d7e0098d", size = 10182, upload-time = "2025-11-03T13:21:11.102Z" },
 ]
 
 [[package]]
@@ -889,7 +930,8 @@ dependencies = [
     { name = "transformers" },
     { name = "typer" },
     { name = "wandb" },
-    { name = "zarr" },
+    { name = "zarr", version = "3.1.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "zarr", version = "3.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 
 [package.optional-dependencies]
@@ -907,7 +949,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anndata", specifier = ">=0.8.0" },
+    { name = "anndata", specifier = ">=0.12.0" },
     { name = "autopep8", marker = "extra == 'dev'", specifier = ">=2.0.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
     { name = "coverage", marker = "extra == 'dev'", specifier = ">=7.3.0" },
@@ -927,7 +969,7 @@ requires-dist = [
     { name = "transformers", specifier = ">=4.20.0" },
     { name = "typer", specifier = ">=0.9.0" },
     { name = "wandb", specifier = ">=0.21.0" },
-    { name = "zarr", specifier = ">=2.12.0,<3" },
+    { name = "zarr", specifier = ">=3.0.0" },
 ]
 provides-extras = ["dev"]
 
@@ -1395,6 +1437,40 @@ wheels = [
 ]
 
 [[package]]
+name = "scverse-misc"
+version = "0.0.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12' and sys_platform == 'linux'",
+    "python_full_version < '3.12' and sys_platform != 'linux'",
+]
+dependencies = [
+    { name = "session-info2", marker = "python_full_version < '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/05/6123a4362e2810ef216f152e249a66799f9c37975dabf89b69abb2d68c42/scverse_misc-0.0.3.tar.gz", hash = "sha256:18c46eeeac8ccef8f435e41a8ee86173b3d7ef6ea1167fde97a17553f70d3210", size = 23128, upload-time = "2026-04-10T15:12:21.731Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/3e/9dad188e00d08f5381b95dd1f8f7b1dc9eb244250d93fea3e9cb7d0e61f0/scverse_misc-0.0.3-py3-none-any.whl", hash = "sha256:295702368db8f5fe946b5296135990492b3fc891a45bd6dd27798775db4c61c6", size = 8845, upload-time = "2026-04-10T15:12:20.366Z" },
+]
+
+[[package]]
+name = "scverse-misc"
+version = "0.0.8"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'linux'",
+    "python_full_version >= '3.12' and sys_platform != 'linux'",
+]
+dependencies = [
+    { name = "session-info2", marker = "python_full_version >= '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.12.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/2e/2fc93b1c9a7dc3c9c44ba8d239a094d21c8cbf3219a57213fc14a7e9bf28/scverse_misc-0.0.8.tar.gz", hash = "sha256:7de6d46e50fc111d366d60b07f165531de97a836a4d702bbbfa2a47a0015fd9e", size = 31621, upload-time = "2026-06-08T12:01:27.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/58/3c753c43fed0a96db29b787daa1dacd84acc8f484da5dd5f8627601a4e4a/scverse_misc-0.0.8-py3-none-any.whl", hash = "sha256:dc61dbd9a1bdb1171cda9f73c52567e29159d51ff1a0f24bee2e568ca1f96a4a", size = 13955, upload-time = "2026-06-08T12:01:26.639Z" },
+]
+
+[[package]]
 name = "sentry-sdk"
 version = "2.32.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1405,6 +1481,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/10/59/eb90c45cb836cf8bec973bba10230ddad1c55e2b2e9ffa9d7d7368948358/sentry_sdk-2.32.0.tar.gz", hash = "sha256:9016c75d9316b0f6921ac14c8cd4fb938f26002430ac5be9945ab280f78bec6b", size = 334932, upload-time = "2025-06-27T08:10:02.89Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/01/a1/fc4856bd02d2097324fb7ce05b3021fb850f864b83ca765f6e37e92ff8ca/sentry_sdk-2.32.0-py2.py3-none-any.whl", hash = "sha256:6cf51521b099562d7ce3606da928c473643abe99b00ce4cb5626ea735f4ec345", size = 356122, upload-time = "2025-06-27T08:10:01.424Z" },
+]
+
+[[package]]
+name = "session-info2"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/17/c6a81d91781734bd10d7842c32de665f34395b4db234abdc80dac271632b/session_info2-0.4.1.tar.gz", hash = "sha256:3bb2bf7b73b2e13a1737e9aa91a6dae55e2c49e83bee973f24245f31ae264a1f", size = 25207, upload-time = "2026-04-08T11:30:55.959Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/d7/6893c9c2a52e4bcbeca2a2bf2aee970a686cc7bf555f97db13b00f35250e/session_info2-0.4.1-py3-none-any.whl", hash = "sha256:423b3f6bb7023433cfc3f791a6fdbb6a2cfbe226770ae6c127c3b2c4cf5a9d56", size = 17696, upload-time = "2026-04-08T11:30:54.707Z" },
 ]
 
 [[package]]
@@ -1797,17 +1882,44 @@ wheels = [
 
 [[package]]
 name = "zarr"
-version = "2.18.7"
+version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "asciitree" },
-    { name = "fasteners", marker = "sys_platform != 'emscripten'" },
-    { name = "numcodecs" },
-    { name = "numpy" },
+resolution-markers = [
+    "python_full_version < '3.12' and sys_platform == 'linux'",
+    "python_full_version < '3.12' and sys_platform != 'linux'",
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/da/1d/01cf9e3ab2d85190278efc3fca9f68563de35ae30ee59e7640e3af98abe3/zarr-2.18.7.tar.gz", hash = "sha256:b2b8f66f14dac4af66b180d2338819981b981f70e196c9a66e6bfaa9e59572f5", size = 3604558, upload-time = "2025-04-09T07:59:28.482Z" }
+dependencies = [
+    { name = "donfig", marker = "python_full_version < '3.12'" },
+    { name = "google-crc32c", marker = "python_full_version < '3.12'" },
+    { name = "numcodecs", marker = "python_full_version < '3.12'" },
+    { name = "numpy", marker = "python_full_version < '3.12'" },
+    { name = "packaging", marker = "python_full_version < '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/31/5a/b8a0cf39a14c770c30bd1f2d120c54000c8cd9e84e8e79f38d9a7ce58071/zarr-3.1.6.tar.gz", hash = "sha256:d95e72cbea4b90e9a70679468b8266400331756232576ae2b43400ac5108d0eb", size = 386531, upload-time = "2026-03-23T17:25:18.748Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/d8/9ffd8c237b3559945bb52103cf0eed64ea098f7b7f573f8d2962ef27b4b2/zarr-2.18.7-py3-none-any.whl", hash = "sha256:ac3dc4033e9ae4e9d7b5e27c97ea3eaf1003cc0a07f010bd83d5134bf8c4b223", size = 211273, upload-time = "2025-04-09T07:59:27.039Z" },
+    { url = "https://files.pythonhosted.org/packages/de/7c/ba8ca8cbe9dbef8e83a95fc208fed8e6686c98b4719aaa0aa7f3d31fe390/zarr-3.1.6-py3-none-any.whl", hash = "sha256:b5a82c5079d1c3d4ee8f06746fa3b9a98a7d804300fa3f4be154362a33e1207e", size = 295655, upload-time = "2026-03-23T17:25:17.189Z" },
+]
+
+[[package]]
+name = "zarr"
+version = "3.2.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'linux'",
+    "python_full_version >= '3.12' and sys_platform != 'linux'",
+]
+dependencies = [
+    { name = "donfig", marker = "python_full_version >= '3.12'" },
+    { name = "google-crc32c", marker = "python_full_version >= '3.12'" },
+    { name = "numcodecs", marker = "python_full_version >= '3.12'" },
+    { name = "numpy", marker = "python_full_version >= '3.12'" },
+    { name = "packaging", marker = "python_full_version >= '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/93/8d/aeb164004f87543b06ef54f885d02c342c31ceb274e2bbec470a98927621/zarr-3.2.1.tar.gz", hash = "sha256:71565b738a0e7e8ed226f0516eba8c6bb53440ad7669a8c48ebb3534a161d035", size = 675161, upload-time = "2026-05-05T12:37:22.383Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/0a/469e2bd01be1490336e6c8707386845655d59261543315778a3ccc7e8019/zarr-3.2.1-py3-none-any.whl", hash = "sha256:f78cdd3d9687ad0e9f9cba2c5683b64f0c52589c19f685eeabe872e93cc0d2c7", size = 319617, upload-time = "2026-05-05T12:37:20.66Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

First, fully-offline slice of the **PR #2 data layer**. It establishes the
organism-aware gene handling, internal normalization, and the single
`(counts, covariates)` minibatch contract that the CELLxGENE Census streaming
loader will reuse — so the heavy TileDB-SOMA dependency and its network-gated
test can land cleanly in slice 2 without reworking the API.

PR #2 was deliberately split (see `docs/STATUS.md` and the decisions log); this
PR is **slice 1 of 2**.

## What's included

- **`data/normalize.py`** — per-cell size factors (`total` / `ratio` modes) and
  internal `log1p` + depth normalization (scVI-style), for dense and sparse
  inputs. Empty cells are handled safely (no divide-by-zero).
- **`data/dataset.py`**
  - `GeneVocabulary` — ordered, per-organism reference gene set (warns on
    organisms outside the v1-supported `{homo_sapiens, mus_musculus}`).
  - `align_to_reference` — maps any source onto the reference ordering:
    zero-fill missing genes, drop extras, warn on low overlap.
  - `Minibatch(counts, size_factors, covariates)` dataclass — the shared
    contract; covariates always carry `organism` + `batch` id (v1 is
    unconditional, but the format already supports later conditioning).
  - `CountsDataset` + `collate_minibatch`.
- **`data/anndata_io.py`** — local `.h5ad` / `.zarr` loaders and
  `build_anndata_dataloader(...)` producing the shared `Minibatch` contract.
  **Human and mouse AnnData iterate through the same DataLoader API** (exit
  criterion for the local path).

## Dependency / tooling note

- Bumped to `zarr>=3.0.0` + `anndata>=0.12.0` (anndata 0.12 adds zarr-python v3
  support) and refreshed `uv.lock`. Verified on anndata 0.12.17 + zarr 3.1.6.
  _(An earlier commit on this branch temporarily pinned `zarr<3` for
  anndata 0.11; that pin was dropped per maintainer request.)_
- Added a mypy override (`ignore_missing_imports`) for the un-stubbed
  `anndata.*` / `scipy.*`.

## Tests & CI

- New `tests/data/` suite with tiny synthetic fixtures — **fully offline**,
  100% coverage on the new modules.
- `make ci` green: black, isort, flake8, **mypy strict**, pytest.

## Not in this PR (→ slice 2)

- `data/census.py` Census streaming via `cellxgene_census` + `tiledbsoma` +
  `tiledbsoma_ml` (adds those deps + a network-gated, skippable live test),
  reusing `GeneVocabulary` / `align_to_reference` / `Minibatch` from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)