### PR TITLE
docs: codify code patterns/idioms in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,24 @@ Individual gates: `make lint`, `make type-check` (mypy strict on `src/omvqvae`),
 - **Dependencies**: add a new dep only in the PR that first uses it, and refresh
   `uv.lock` (`uv lock`) in the same change.
 
+## Code patterns / idioms
+
+The data layer established these structural conventions; keep following them as
+new packages (`layers/`, `models/`, `train/`, …) land.
+
+- **Inject data sources** into loaders/components (pass the iterable or handle
+  in) so tests can substitute a plain list — don't construct the source inside
+  the class. This is why `CensusMinibatchLoader` is testable offline.
+- **Networked/heavy logic = pure core + thin I/O shell.** Keep the real work in
+  pure-Python functions tested offline with synthetic fixtures; mark the live
+  shell `@pytest.mark.network` (skipped by default) and `# pragma: no cover`.
+- **Lazy-import heavy deps** (`torch`, `cellxgene_census`, `anndata`, …) inside
+  the function that uses them; put type-only imports under `if TYPE_CHECKING`.
+  Keeps `import omvqvae` fast and optional deps optional.
+- **`@dataclass` for plain data bundles; a validating class for anything with
+  invariants** (raise in `__init__`). `Minibatch` is a dataclass; `GeneVocabulary`
+  is a hand-written class that rejects empty/duplicate gene ids.
+
 ## Git / PR workflow
 
 - Each automated run works on a fresh branch off the latest `main`


### PR DESCRIPTION
## What

Adds a **"Code patterns / idioms"** subsection to `CLAUDE.md`, right after the Conventions list. Four prescriptive bullets capturing the structural conventions the data layer already follows:

- **Inject data sources** into loaders/components so tests substitute a plain list (no mocking) — cites `CensusMinibatchLoader`.
- **Networked/heavy logic = pure core + thin I/O shell**: pure functions tested offline with synthetic fixtures; live shell marked `@pytest.mark.network` + `# pragma: no cover`.
- **Lazy-import heavy deps** (`torch`, `cellxgene_census`, `anndata`, …) inside the using function; type-only imports under `if TYPE_CHECKING`.
- **`@dataclass` for plain data bundles; a validating class for invariants** — `Minibatch` vs `GeneVocabulary` contrast.

## Why

These patterns are currently implicit — only discoverable by reading the data layer. With `layers/`, `models/`, and `train/` still empty, the next PRs (starting with PR #3's residual VQ layer) could easily diverge. Writing them down as standing rules keeps the codebase consistent as it grows.

The architectural *why* (the `Minibatch` contract, raw-count/NB-ZINB, test strategy) is already well covered in `PROJECT_PLAN.md` and its decisions log, so this intentionally adds only the repeatable *code-shape* conventions, not a duplicate of that material or general Python tutorial content.

## Reviewer notes

- Docs-only change; no code touched. `make ci` is unaffected.
- Scoped to a single subsection in `CLAUDE.md` (+18 lines).

Co-Authored-By: Claude <noreply@anthropic.com>