### PR TITLE
feat(layers): residual vector quantizer (PR #3)

### DIFF
--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -244,12 +244,16 @@ src/omvqvae/
   a local AnnData through the *same* DataLoader API; tests with a tiny offline
   fixture (live-Census tests marked/skippable); strict mypy + bounded memory.
 
-#### **PR #3: Residual Vector Quantizer Layer**
+#### **PR #3: Residual Vector Quantizer Layer — ✅ DONE**
 - **Scope**: configurable residual VQ with straight-through estimator.
 - **Files**: `layers/residual_vq.py`.
-- **Key features**: configurable codebook count/size, commitment loss,
-  perplexity/utilization metrics, codebook reset/EMA option.
-- **Exit criteria**: high test coverage, gradient-flow verification.
+- **Key features**: `VectorQuantizer` (single codebook) + `ResidualVQ` (stacked
+  over residuals, `n_codebooks` default 2), straight-through estimator,
+  commitment + codebook losses, optional EMA codebook updates (Laplace-smoothed)
+  and dead-code reset, per-forward perplexity/utilization metrics returned via
+  `QuantizerOutput` / `ResidualVQOutput`.
+- **Exit criteria**: 100% offline test coverage on the module, straight-through
+  gradient-flow verification, strict mypy — all met; `make ci` green.
 
 ### **Phase 2: Core Model (PRs 4–6)**
 
@@ -375,6 +379,7 @@ A running record of decisions so future sessions don't re-litigate them.
 | 2026-06-19 | **Census streaming uses `tiledbsoma_ml.ExperimentDataset` + `experiment_dataloader`** wrapped by `CensusMinibatchLoader`, which adapts each streamed `(X, obs)` chunk to the shared `Minibatch` via `census_chunk_to_minibatch`. The chunk→`Minibatch` glue is pure-Python (tested offline with synthetic fixtures); the live TileDB-SOMA wiring is a single `network`-marked test (skipped by default). | Keeps the heavy/networked path thin and the contract glue 100%-covered offline; reuses `GeneVocabulary`/`align_to_reference` so Census and local AnnData share one downstream API. |
 | 2026-06-19 | **Pin `DEFAULT_CENSUS_VERSION = "2025-11-08"`** (newest LTS at implementation time), configurable per call. Default reference gene set = the full Census `var` index for the organism. | Reproducible streaming; supersedes the earlier `2025-01-30` note. A curated/HVG gene panel can be selected later via `var_value_filter` in the model PRs. |
 | 2026-06-19 | **Register a `network` pytest marker, skipped by default** via `addopts = [..., "-m", "not network"]`; run live tests with `pytest -m network -o addopts=""`. | Keeps CI offline-by-default while still shipping an executable end-to-end Census check. |
+| 2026-06-20 | **Residual VQ = `VectorQuantizer` (one codebook) composed by `ResidualVQ` (stacks N over residuals, default 2).** EMA codebook updates are the default (`ema=True`) with dead-code reset; non-EMA falls back to a gradient-trained codebook + codebook-pull loss. Forward returns a `QuantizerOutput`/`ResidualVQOutput` dataclass bundling quantized vectors, indices, split losses, and perplexity/utilization metrics. | EMA + dead-code reset is the standard collapse-resistant VQ recipe (VQ-VAE-2); the dataclass result keeps the model/training PRs decoupled from the quantizer internals and gives PR #5/#9 their monitoring signals for free. |
 
 ## 🔄 **Future Roadmap (Post-v1.0)**
 - **Other omics modalities**: extend the discrete-codebook approach beyond
@@ -391,7 +396,8 @@ A running record of decisions so future sessions don't re-litigate them.
 
 ---
 
-**Last Updated**: 2026-06-17 — clarified multi-organism (human + mouse) support,
-v1-unconditional decision, and added the design-decisions log.
-**Current Focus**: PR #3 — residual vector-quantizer layer (see `docs/STATUS.md`).
-**Next Review**: After PR #3 (residual VQ layer).
+**Last Updated**: 2026-06-20 — PR #3 (residual VQ layer) landed; next focus is
+the VQ-VAE core model.
+**Current Focus**: PR #4 — VQ-VAE core model (raw-count NB/ZINB) (see
+`docs/STATUS.md`).
+**Next Review**: After PR #4 (VQ-VAE core model).

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -4,7 +4,7 @@
 > end of every working session** so the next session can pick up cold. Keep it
 > short; deep rationale lives in `docs/PROJECT_PLAN.md`.
 
-**Last updated:** 2026-06-19
+**Last updated:** 2026-06-20
 
 ## Current state
 
@@ -34,27 +34,43 @@
     "2025-11-08"` (newest LTS). Offline tests at 100% coverage; a `network`-marked
     live test streams **human and mouse** end-to-end (skipped by default,
     verified passing live this run). `make ci` green.
+- **PR #3 (residual VQ layer) — DONE (this PR).**
+  - `layers/residual_vq.py` — `VectorQuantizer` (single codebook: straight-through
+    estimator, commitment + codebook losses, optional EMA codebook updates with
+    Laplace smoothing, dead-code reset) and `ResidualVQ` (stacks `n_codebooks`
+    quantizers over successive residuals; per-level indices = the cell's discrete
+    code; summed quantized vectors approximate the input).
+  - Per-forward monitoring metrics exposed via `QuantizerOutput` /
+    `ResidualVQOutput` dataclasses: codebook **perplexity** (per-level + mean)
+    and **utilization**, plus split commitment/codebook/total losses — ready for
+    PR #5's W&B logging and PR #9's collapse checks.
+  - Offline synthetic tests (`tests/layers/test_residual_vq.py`): shapes/dtypes,
+    leading-dim preservation, straight-through gradient flow (identity gradient),
+    EMA-buffer vs trained-parameter codebook, EMA update moves the codebook,
+    dead-code reset (active + no-op paths), non-trivial perplexity, residual-norm
+    reduction with more levels, and input-validation errors. 100% coverage on the
+    new module; `make ci` green. No new dependencies (torch already present).
 - Plan/docs reflect the pivot: Census streaming, raw-count NB/ZINB modeling,
   discrete universal latent space, human+mouse, v1 unconditional, W&B monitoring.
 
-## Next task — PR #3: Residual Vector Quantizer layer
+## Next task — PR #4: VQ-VAE core model (raw-count, NB/ZINB)
 
-With the data layer complete, build the discrete bottleneck.
+With the data layer and the discrete bottleneck in place, assemble the model.
 
-1. `layers/residual_vq.py` — a configurable residual VQ module: `n_codebooks`
-   (default 2), codebook size/dim, straight-through estimator for gradient flow,
-   commitment + codebook losses, and EMA / dead-code reset option.
-2. Expose per-forward metrics for monitoring: codebook **perplexity** /
-   utilization and quantization loss, so PR #5's W&B logging and PR #9's
-   collapse checks have them.
-3. Tests (offline, synthetic): shapes/dtypes, gradient flow through the
-   straight-through estimator, that codebooks are utilized (non-trivial
-   perplexity), and that EMA/reset paths run. Keep `make ci` green (strict mypy,
-   coverage).
+1. `models/likelihoods.py` — NB (default) and ZINB reconstruction heads (and a
+   Gaussian-on-log1p alternative), each mapping decoder outputs (+ observed size
+   factor) to a likelihood and a negative-log-likelihood loss over genes.
+2. `models/vqvae.py` — encoder → `ResidualVQ` → decoder. Encoder applies the
+   internal log1p (see `data/normalize.py`); decoder consumes quantized codes +
+   size factor and emits likelihood params. Compose the loss = reconstruction NLL
+   + VQ loss; surface codebook perplexity/utilization for logging.
+3. Tests (offline, synthetic): a 2-epoch smoke train on synthetic counts where
+   the loss decreases; NB and ZINB heads both train; codebooks stay utilized
+   (non-trivial perplexity). Keep `make ci` green (strict mypy, coverage).
 
-**Definition of done:** a residual VQ layer that quantizes encoder outputs to a
-set of codebook indices, returns quantized vectors + indices + losses + metrics,
-back-props through the bottleneck; offline tests; CI green; PR opened.
+**Definition of done:** a VQ-VAE that ingests raw counts, quantizes via
+`ResidualVQ`, reconstructs counts under NB/ZINB, trains on a synthetic smoke
+test; offline tests; CI green; PR opened.
 
 ## Open questions / parked
 
@@ -73,6 +89,15 @@ back-props through the bottleneck; offline tests; CI green; PR opened.
 
 ## Changelog (most recent first)
 
+- **2026-06-20** — PR #3: residual vector-quantizer layer. Added
+  `layers/residual_vq.py` (`VectorQuantizer`, `ResidualVQ`, and the
+  `QuantizerOutput` / `ResidualVQOutput` result bundles): straight-through
+  estimator, commitment + codebook losses, optional EMA codebook updates with
+  Laplace smoothing, dead-code reset, and per-forward perplexity/utilization
+  metrics. `ResidualVQ` stacks `n_codebooks` (default 2) quantizers over
+  successive residuals so each cell becomes a small set of codebook indices.
+  Exported from `layers/__init__.py`. Offline synthetic tests at 100% coverage;
+  no new dependencies; `make ci` green.
 - **2026-06-19** — PR #2 slice 2: CELLxGENE Census streaming. Added
   `data/census.py` (`open_census`, `census_gene_vocabulary`,
   `census_chunk_to_minibatch`, `CensusMinibatchLoader`,

--- a/src/omvqvae/layers/__init__.py
+++ b/src/omvqvae/layers/__init__.py
@@ -1,1 +1,15 @@
 """Neural network layers for VQ-VAE models."""
+
+from omvqvae.layers.residual_vq import (
+    QuantizerOutput,
+    ResidualVQ,
+    ResidualVQOutput,
+    VectorQuantizer,
+)
+
+__all__ = [
+    "QuantizerOutput",
+    "ResidualVQOutput",
+    "VectorQuantizer",
+    "ResidualVQ",
+]

--- a/src/omvqvae/layers/residual_vq.py
+++ b/src/omvqvae/layers/residual_vq.py
@@ -1,0 +1,454 @@
+"""
+Residual vector quantization for OQAE.
+
+This module implements the discrete bottleneck of the OQAE VQ-VAE: a stack of
+vector-quantization codebooks applied to *residuals*, so each encoder output is
+represented as a small set of codebook indices — the discrete, universal code
+for a cell.
+
+The building blocks are:
+
+- :class:`VectorQuantizer` — a single codebook with a straight-through
+  estimator, commitment/codebook losses, optional EMA codebook updates, and
+  dead-code reset. It also reports per-forward monitoring metrics (codebook
+  **perplexity** and **utilization**).
+- :class:`ResidualVQ` — stacks ``n_codebooks`` quantizers; codebook ``i`` + 1
+  quantizes the residual left by the previous codebooks. The sum of the
+  per-level quantized vectors approximates the input; the per-level indices are
+  the cell's discrete code.
+
+Both return small dataclasses (:class:`QuantizerOutput` / :class:`ResidualVQOutput`)
+bundling the quantized vectors, indices, losses, and metrics so the model and
+W&B-logging PRs can consume them uniformly.
+
+Design notes
+------------
+- Gradients flow through the discrete argmin via the straight-through estimator
+  (``quantized = x + (quantized - x).detach()``), so the encoder trains end to
+  end.
+- With ``ema=True`` the codebook is updated by an exponential moving average of
+  assigned encoder outputs (scVI/VQ-VAE-2 style) instead of by gradient descent,
+  which is typically more stable; the codebook-pull loss term is then dropped
+  and only the commitment loss is kept.
+- Dead codes (codebook entries that go unused) are periodically reset to random
+  encoder outputs from the current batch to guard against codebook collapse.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+import torch
+from torch import Tensor, nn
+
+from omvqvae.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+__all__ = [
+    "QuantizerOutput",
+    "ResidualVQOutput",
+    "VectorQuantizer",
+    "ResidualVQ",
+]
+
+
+@dataclass
+class QuantizerOutput:
+    """
+    Output of a single :class:`VectorQuantizer` forward pass.
+
+    Attributes
+    ----------
+    quantized : torch.Tensor
+        Quantized vectors of the same shape as the input, carrying the
+        straight-through gradient back to the encoder.
+    indices : torch.Tensor
+        Selected codebook indices of shape ``input.shape[:-1]`` (``int64``).
+    loss : torch.Tensor
+        Scalar VQ loss for this codebook (codebook + weighted commitment term;
+        codebook term is zero under EMA).
+    commitment_loss : torch.Tensor
+        Scalar commitment loss pulling encoder outputs toward the codebook.
+    codebook_loss : torch.Tensor
+        Scalar codebook loss pulling the codebook toward encoder outputs
+        (always zero under EMA updates).
+    perplexity : torch.Tensor
+        Scalar codebook perplexity for this batch (``exp`` of the assignment
+        entropy); higher means more codes are used evenly.
+    usage : torch.Tensor
+        Scalar fraction of codebook entries assigned at least one input in this
+        batch (in ``[0, 1]``).
+    """
+
+    quantized: Tensor
+    indices: Tensor
+    loss: Tensor
+    commitment_loss: Tensor
+    codebook_loss: Tensor
+    perplexity: Tensor
+    usage: Tensor
+
+
+@dataclass
+class ResidualVQOutput:
+    """
+    Output of a :class:`ResidualVQ` forward pass.
+
+    Attributes
+    ----------
+    quantized : torch.Tensor
+        Sum of the per-level quantized vectors (same shape as the input),
+        carrying the straight-through gradient back to the encoder.
+    indices : torch.Tensor
+        Per-level codebook indices of shape ``input.shape[:-1] + (n_codebooks,)``
+        (``int64``); this is the cell's discrete code.
+    loss : torch.Tensor
+        Scalar total VQ loss summed over codebooks.
+    commitment_loss : torch.Tensor
+        Scalar commitment loss summed over codebooks.
+    codebook_loss : torch.Tensor
+        Scalar codebook loss summed over codebooks (zero under EMA updates).
+    perplexity : torch.Tensor
+        Scalar mean codebook perplexity across levels.
+    perplexities : torch.Tensor
+        Per-level perplexities of shape ``(n_codebooks,)``.
+    usages : torch.Tensor
+        Per-level codebook utilization of shape ``(n_codebooks,)``.
+    """
+
+    quantized: Tensor
+    indices: Tensor
+    loss: Tensor
+    commitment_loss: Tensor
+    codebook_loss: Tensor
+    perplexity: Tensor
+    perplexities: Tensor
+    usages: Tensor
+
+
+class VectorQuantizer(nn.Module):
+    """
+    A single vector-quantization codebook with a straight-through estimator.
+
+    Parameters
+    ----------
+    codebook_size : int
+        Number of codebook entries (vocabulary size for this codebook).
+    embedding_dim : int
+        Dimensionality of each codebook vector (must match the encoder output).
+    commitment_cost : float, default 0.25
+        Weight ``beta`` on the commitment loss in the total VQ loss.
+    ema : bool, default True
+        If ``True``, update the codebook with an exponential moving average of
+        assigned encoder outputs instead of by gradient descent; the codebook
+        loss term is then dropped.
+    ema_decay : float, default 0.99
+        EMA decay used when ``ema=True``.
+    ema_epsilon : float, default 1e-5
+        Laplace-smoothing constant for EMA cluster sizes.
+    reset_dead_codes : bool, default True
+        If ``True``, reset codes whose usage EMA falls below
+        ``dead_code_threshold`` to random encoder outputs from the batch
+        (collapse guard); only active in training mode.
+    dead_code_threshold : float, default 1.0
+        Usage-EMA threshold below which a code is considered dead.
+
+    Raises
+    ------
+    ValueError
+        If ``codebook_size`` or ``embedding_dim`` is not positive, or if
+        ``ema_decay`` is not in ``[0, 1)``.
+    """
+
+    # Registered as buffers/parameter in ``__init__``; declared here so the
+    # static type checker treats them as tensors rather than ``Tensor | Module``
+    # (the return type of ``nn.Module.__getattr__``).
+    embedding: Tensor
+    cluster_size: Tensor
+    embed_avg: Tensor
+
+    def __init__(
+        self,
+        codebook_size: int,
+        embedding_dim: int,
+        *,
+        commitment_cost: float = 0.25,
+        ema: bool = True,
+        ema_decay: float = 0.99,
+        ema_epsilon: float = 1e-5,
+        reset_dead_codes: bool = True,
+        dead_code_threshold: float = 1.0,
+    ) -> None:
+        super().__init__()
+        if codebook_size <= 0:
+            raise ValueError("codebook_size must be a positive integer.")
+        if embedding_dim <= 0:
+            raise ValueError("embedding_dim must be a positive integer.")
+        if not 0.0 <= ema_decay < 1.0:
+            raise ValueError("ema_decay must be in [0, 1).")
+
+        self.codebook_size = codebook_size
+        self.embedding_dim = embedding_dim
+        self.commitment_cost = commitment_cost
+        self.ema = ema
+        self.ema_decay = ema_decay
+        self.ema_epsilon = ema_epsilon
+        self.reset_dead_codes = reset_dead_codes
+        self.dead_code_threshold = dead_code_threshold
+
+        embedding = torch.randn(codebook_size, embedding_dim)
+        # Under EMA the codebook is a buffer updated in-place (no autograd);
+        # otherwise it is a learnable parameter optimized by gradient descent.
+        if ema:
+            self.register_buffer("embedding", embedding)
+        else:
+            self.embedding = nn.Parameter(embedding)
+
+        # EMA statistics / usage tracker (kept regardless of update rule so the
+        # dead-code reset has a usage signal to act on).
+        self.register_buffer("cluster_size", torch.zeros(codebook_size))
+        self.register_buffer("embed_avg", embedding.clone())
+
+    def _codebook(self) -> Tensor:
+        """Return the codebook tensor (buffer under EMA, parameter otherwise)."""
+        embedding: Tensor = self.embedding
+        return embedding
+
+    def forward(self, inputs: Tensor) -> QuantizerOutput:
+        """
+        Quantize ``inputs`` to the nearest codebook entries.
+
+        Parameters
+        ----------
+        inputs : torch.Tensor
+            Encoder outputs of shape ``(..., embedding_dim)``.
+
+        Returns
+        -------
+        QuantizerOutput
+            Quantized vectors, indices, losses, and monitoring metrics.
+
+        Raises
+        ------
+        ValueError
+            If the last dimension of ``inputs`` is not ``embedding_dim``.
+        """
+        if inputs.shape[-1] != self.embedding_dim:
+            raise ValueError(
+                f"inputs last dim {inputs.shape[-1]} != embedding_dim "
+                f"{self.embedding_dim}."
+            )
+
+        leading_shape = inputs.shape[:-1]
+        flat = inputs.reshape(-1, self.embedding_dim)
+        codebook = self._codebook()
+
+        # Squared Euclidean distances to every codebook entry: (N, codebook_size).
+        distances = (
+            flat.pow(2).sum(dim=1, keepdim=True)
+            - 2.0 * flat @ codebook.t()
+            + codebook.pow(2).sum(dim=1)
+        )
+        indices = distances.argmin(dim=1)
+        encodings = torch.zeros(
+            flat.shape[0], self.codebook_size, device=flat.device, dtype=flat.dtype
+        )
+        encodings.scatter_(1, indices.unsqueeze(1), 1.0)
+
+        quantized_flat = codebook[indices]
+
+        # VQ losses. The commitment term pulls the encoder toward the codebook;
+        # the codebook term pulls the codebook toward the encoder (skipped under
+        # EMA, where the codebook is updated by moving average instead).
+        commitment_loss = torch.mean((flat - quantized_flat.detach()) ** 2)
+        if self.ema:
+            codebook_loss = torch.zeros((), device=flat.device, dtype=flat.dtype)
+        else:
+            codebook_loss = torch.mean((flat.detach() - quantized_flat) ** 2)
+        loss = codebook_loss + self.commitment_cost * commitment_loss
+
+        # Straight-through estimator: copy gradients from quantized to inputs.
+        quantized_flat = flat + (quantized_flat - flat).detach()
+
+        if self.training:
+            self._update_usage(encodings)
+            if self.ema:
+                self._ema_update(flat, encodings)
+            if self.reset_dead_codes:
+                self._reset_dead_codes(flat)
+
+        perplexity, usage = self._metrics(encodings)
+
+        quantized = quantized_flat.reshape(*leading_shape, self.embedding_dim)
+        indices_out = indices.reshape(leading_shape)
+        return QuantizerOutput(
+            quantized=quantized,
+            indices=indices_out,
+            loss=loss,
+            commitment_loss=commitment_loss,
+            codebook_loss=codebook_loss,
+            perplexity=perplexity,
+            usage=usage,
+        )
+
+    @torch.no_grad()
+    def _update_usage(self, encodings: Tensor) -> None:
+        """Update the EMA usage tracker from this batch's assignments."""
+        counts = encodings.sum(dim=0)
+        self.cluster_size.mul_(self.ema_decay).add_(counts, alpha=1.0 - self.ema_decay)
+
+    @torch.no_grad()
+    def _ema_update(self, flat: Tensor, encodings: Tensor) -> None:
+        """Update the codebook by an EMA of assigned encoder outputs."""
+        embed_sum = encodings.t() @ flat
+        self.embed_avg.mul_(self.ema_decay).add_(embed_sum, alpha=1.0 - self.ema_decay)
+        # Laplace smoothing keeps unused codes from collapsing to zero.
+        n = self.cluster_size.sum()
+        smoothed = (
+            (self.cluster_size + self.ema_epsilon)
+            / (n + self.codebook_size * self.ema_epsilon)
+            * n
+        )
+        self._codebook().copy_(self.embed_avg / smoothed.unsqueeze(1))
+
+    @torch.no_grad()
+    def _reset_dead_codes(self, flat: Tensor) -> None:
+        """Reset under-used codebook entries to random encoder outputs."""
+        dead = self.cluster_size < self.dead_code_threshold
+        n_dead = int(dead.sum().item())
+        if n_dead == 0:
+            return
+        # Sample replacement vectors (with replacement) from the current batch.
+        sample_idx = torch.randint(0, flat.shape[0], (n_dead,), device=flat.device)
+        replacements = flat[sample_idx]
+        codebook = self._codebook()
+        codebook[dead] = replacements
+        self.embed_avg[dead] = replacements
+        self.cluster_size[dead] = 1.0
+        logger.debug("Reset %d dead codebook entries.", n_dead)
+
+    def _metrics(self, encodings: Tensor) -> tuple[Tensor, Tensor]:
+        """Compute batch perplexity and codebook utilization."""
+        avg_probs = encodings.mean(dim=0)
+        # exp(entropy); add eps inside log for numerical stability.
+        perplexity = torch.exp(-torch.sum(avg_probs * torch.log(avg_probs + 1e-10)))
+        usage = (avg_probs > 0).to(avg_probs.dtype).mean()
+        return perplexity, usage
+
+
+class ResidualVQ(nn.Module):
+    """
+    A stack of vector quantizers applied to successive residuals.
+
+    Each cell's encoder output is quantized by the first codebook; the residual
+    (input minus its quantization) is quantized by the second codebook, and so
+    on. The per-level indices form the cell's discrete code and the per-level
+    quantized vectors sum to an approximation of the input.
+
+    Parameters
+    ----------
+    n_codebooks : int, default 2
+        Number of residual quantization levels.
+    codebook_size : int
+        Number of entries in each codebook.
+    embedding_dim : int
+        Dimensionality of the encoder output / codebook vectors.
+    commitment_cost : float, default 0.25
+        Commitment-loss weight passed to every :class:`VectorQuantizer`.
+    ema : bool, default True
+        Whether each codebook is updated by EMA (see :class:`VectorQuantizer`).
+    ema_decay : float, default 0.99
+        EMA decay for the codebooks.
+    reset_dead_codes : bool, default True
+        Whether each codebook resets dead entries (collapse guard).
+
+    Raises
+    ------
+    ValueError
+        If ``n_codebooks`` is not a positive integer.
+    """
+
+    def __init__(
+        self,
+        *,
+        codebook_size: int,
+        embedding_dim: int,
+        n_codebooks: int = 2,
+        commitment_cost: float = 0.25,
+        ema: bool = True,
+        ema_decay: float = 0.99,
+        reset_dead_codes: bool = True,
+    ) -> None:
+        super().__init__()
+        if n_codebooks <= 0:
+            raise ValueError("n_codebooks must be a positive integer.")
+
+        self.n_codebooks = n_codebooks
+        self.codebook_size = codebook_size
+        self.embedding_dim = embedding_dim
+        self.quantizers = nn.ModuleList(
+            VectorQuantizer(
+                codebook_size,
+                embedding_dim,
+                commitment_cost=commitment_cost,
+                ema=ema,
+                ema_decay=ema_decay,
+                reset_dead_codes=reset_dead_codes,
+            )
+            for _ in range(n_codebooks)
+        )
+
+    def forward(self, inputs: Tensor) -> ResidualVQOutput:
+        """
+        Quantize ``inputs`` through the residual codebook stack.
+
+        Parameters
+        ----------
+        inputs : torch.Tensor
+            Encoder outputs of shape ``(..., embedding_dim)``.
+
+        Returns
+        -------
+        ResidualVQOutput
+            Summed quantized vectors, per-level indices, summed losses, and
+            per-level / mean monitoring metrics.
+        """
+        residual = inputs
+        quantized_sum = torch.zeros_like(inputs)
+        total_loss = inputs.new_zeros(())
+        total_commitment = inputs.new_zeros(())
+        total_codebook = inputs.new_zeros(())
+
+        indices_list: List[Tensor] = []
+        perplexities: List[Tensor] = []
+        usages: List[Tensor] = []
+
+        for quantizer in self.quantizers:
+            out: QuantizerOutput = quantizer(residual)
+            # Subtract the (straight-through) quantization to form the next
+            # residual; the running sum reconstructs the input.
+            residual = residual - out.quantized
+            quantized_sum = quantized_sum + out.quantized
+
+            total_loss = total_loss + out.loss
+            total_commitment = total_commitment + out.commitment_loss
+            total_codebook = total_codebook + out.codebook_loss
+            indices_list.append(out.indices)
+            perplexities.append(out.perplexity)
+            usages.append(out.usage)
+
+        indices = torch.stack(indices_list, dim=-1)
+        perplexities_t = torch.stack(perplexities)
+        usages_t = torch.stack(usages)
+        return ResidualVQOutput(
+            quantized=quantized_sum,
+            indices=indices,
+            loss=total_loss,
+            commitment_loss=total_commitment,
+            codebook_loss=total_codebook,
+            perplexity=perplexities_t.mean(),
+            perplexities=perplexities_t,
+            usages=usages_t,
+        )

--- a/tests/layers/test_residual_vq.py
+++ b/tests/layers/test_residual_vq.py
@@ -1,0 +1,181 @@
+"""Offline tests for the residual vector-quantization layer."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from omvqvae.layers import (
+    QuantizerOutput,
+    ResidualVQ,
+    ResidualVQOutput,
+    VectorQuantizer,
+)
+
+
+def test_vector_quantizer_shapes_and_dtypes() -> None:
+    torch.manual_seed(0)
+    vq = VectorQuantizer(codebook_size=16, embedding_dim=8)
+    inputs = torch.randn(5, 8)
+    out = vq(inputs)
+
+    assert isinstance(out, QuantizerOutput)
+    assert out.quantized.shape == inputs.shape
+    assert out.quantized.dtype == inputs.dtype
+    assert out.indices.shape == (5,)
+    assert out.indices.dtype == torch.int64
+    assert out.indices.min() >= 0 and out.indices.max() < 16
+    for scalar in (out.loss, out.commitment_loss, out.codebook_loss, out.perplexity):
+        assert scalar.shape == ()
+
+
+def test_vector_quantizer_preserves_leading_dims() -> None:
+    vq = VectorQuantizer(codebook_size=8, embedding_dim=4)
+    inputs = torch.randn(3, 7, 4)
+    out = vq(inputs)
+    assert out.quantized.shape == (3, 7, 4)
+    assert out.indices.shape == (3, 7)
+
+
+def test_straight_through_estimator_passes_gradient() -> None:
+    vq = VectorQuantizer(codebook_size=8, embedding_dim=4, ema=True)
+    vq.eval()  # disable EMA/reset so only the STE path runs
+    inputs = torch.randn(6, 4, requires_grad=True)
+    out = vq(inputs)
+    out.quantized.sum().backward()
+    assert inputs.grad is not None
+    # The straight-through estimator copies an identity gradient.
+    torch.testing.assert_close(inputs.grad, torch.ones_like(inputs))
+
+
+def test_non_ema_codebook_is_a_trained_parameter() -> None:
+    vq = VectorQuantizer(codebook_size=8, embedding_dim=4, ema=False)
+    assert isinstance(vq.embedding, torch.nn.Parameter)
+    params = dict(vq.named_parameters())
+    assert "embedding" in params
+
+    inputs = torch.randn(6, 4)
+    out = vq(inputs)
+    # Non-EMA codebook is pulled toward the encoder via a non-zero codebook loss.
+    assert out.codebook_loss.item() > 0.0
+    out.loss.backward()
+    assert vq.embedding.grad is not None
+
+
+def test_ema_codebook_is_a_buffer_with_zero_codebook_loss() -> None:
+    vq = VectorQuantizer(codebook_size=8, embedding_dim=4, ema=True)
+    buffers = dict(vq.named_buffers())
+    assert "embedding" in buffers
+    assert "embedding" not in dict(vq.named_parameters())
+
+    out = vq(torch.randn(6, 4))
+    assert out.codebook_loss.item() == 0.0
+
+
+def test_ema_update_moves_codebook_in_training() -> None:
+    torch.manual_seed(0)
+    vq = VectorQuantizer(codebook_size=8, embedding_dim=4, ema=True)
+    vq.train()
+    before = vq.embedding.clone()
+    for _ in range(5):
+        vq(torch.randn(32, 4))
+    assert not torch.allclose(before, vq.embedding)
+
+
+def test_dead_code_reset_runs_and_updates_codebook() -> None:
+    torch.manual_seed(0)
+    vq = VectorQuantizer(
+        codebook_size=64,
+        embedding_dim=4,
+        ema=True,
+        reset_dead_codes=True,
+        dead_code_threshold=1.0,
+    )
+    vq.train()
+    before = vq.embedding.clone()
+    # A tiny batch cannot touch all 64 codes, so some are reset.
+    vq(torch.randn(4, 4))
+    assert not torch.allclose(before, vq.embedding)
+    assert torch.all(vq.cluster_size >= 0.0)
+
+
+def test_dead_code_reset_noop_when_no_dead_codes() -> None:
+    vq = VectorQuantizer(
+        codebook_size=8,
+        embedding_dim=4,
+        ema=False,
+        reset_dead_codes=True,
+        dead_code_threshold=0.0,  # nothing is ever below zero usage
+    )
+    vq.train()
+    before = vq.embedding.clone()
+    vq(torch.randn(4, 4))
+    # No code qualifies as dead, so the codebook is untouched by the reset path.
+    torch.testing.assert_close(vq.embedding, before)
+
+
+def test_perplexity_is_non_trivial_with_diverse_inputs() -> None:
+    torch.manual_seed(0)
+    vq = VectorQuantizer(codebook_size=32, embedding_dim=8, ema=False)
+    vq.eval()
+    # Many distinct inputs should spread across several codes.
+    out = vq(torch.randn(256, 8))
+    assert out.perplexity.item() > 1.0
+    assert 0.0 < out.usage.item() <= 1.0
+
+
+def test_vector_quantizer_rejects_bad_init_args() -> None:
+    with pytest.raises(ValueError, match="codebook_size"):
+        VectorQuantizer(codebook_size=0, embedding_dim=4)
+    with pytest.raises(ValueError, match="embedding_dim"):
+        VectorQuantizer(codebook_size=4, embedding_dim=0)
+    with pytest.raises(ValueError, match="ema_decay"):
+        VectorQuantizer(codebook_size=4, embedding_dim=4, ema_decay=1.0)
+
+
+def test_vector_quantizer_rejects_wrong_input_dim() -> None:
+    vq = VectorQuantizer(codebook_size=8, embedding_dim=4)
+    with pytest.raises(ValueError, match="embedding_dim"):
+        vq(torch.randn(3, 5))
+
+
+def test_residual_vq_shapes_and_aggregation() -> None:
+    torch.manual_seed(0)
+    rvq = ResidualVQ(codebook_size=16, embedding_dim=8, n_codebooks=3)
+    inputs = torch.randn(10, 8)
+    out = rvq(inputs)
+
+    assert isinstance(out, ResidualVQOutput)
+    assert out.quantized.shape == inputs.shape
+    assert out.indices.shape == (10, 3)
+    assert out.indices.dtype == torch.int64
+    assert out.perplexities.shape == (3,)
+    assert out.usages.shape == (3,)
+    # Mean perplexity equals the mean of the per-level perplexities.
+    torch.testing.assert_close(out.perplexity, out.perplexities.mean())
+
+
+def test_residual_vq_reduces_residual_norm() -> None:
+    torch.manual_seed(0)
+    # With more levels the summed quantization should track the input better.
+    inputs = torch.randn(64, 8)
+    one = ResidualVQ(codebook_size=64, embedding_dim=8, n_codebooks=1, ema=False)
+    four = ResidualVQ(codebook_size=64, embedding_dim=8, n_codebooks=4, ema=False)
+    err_one = (inputs - one(inputs).quantized).pow(2).mean()
+    err_four = (inputs - four(inputs).quantized).pow(2).mean()
+    assert err_four < err_one
+
+
+def test_residual_vq_gradient_flows_to_input() -> None:
+    rvq = ResidualVQ(codebook_size=16, embedding_dim=8, n_codebooks=2, ema=True)
+    rvq.eval()
+    inputs = torch.randn(5, 8, requires_grad=True)
+    out = rvq(inputs)
+    (out.quantized.sum() + out.loss).backward()
+    assert inputs.grad is not None
+    assert torch.isfinite(inputs.grad).all()
+
+
+def test_residual_vq_rejects_bad_n_codebooks() -> None:
+    with pytest.raises(ValueError, match="n_codebooks"):
+        ResidualVQ(codebook_size=8, embedding_dim=4, n_codebooks=0)


### PR DESCRIPTION
## PR #3 — Residual Vector Quantizer layer

Builds the discrete bottleneck of the OQAE VQ-VAE (next task named in `docs/STATUS.md`).

### What's here
- **`layers/residual_vq.py`**
  - **`VectorQuantizer`** — a single codebook with:
    - straight-through estimator (`quantized = x + (quantized - x).detach()`) so the encoder trains end to end;
    - commitment + codebook losses (the codebook-pull term is dropped under EMA);
    - optional **EMA codebook updates** (Laplace-smoothed cluster sizes, default `ema=True`) vs. gradient-trained codebook;
    - **dead-code reset** — under-used entries are reset to random encoder outputs from the batch (collapse guard);
    - per-forward monitoring: codebook **perplexity** and **utilization**.
  - **`ResidualVQ`** — stacks `n_codebooks` (default 2) quantizers over successive residuals; per-level indices form the cell's discrete code and the summed quantized vectors approximate the input.
  - **`QuantizerOutput` / `ResidualVQOutput`** dataclasses bundle quantized vectors, indices, split losses, and metrics so PR #4 (model) and PR #5 (W&B logging) consume them uniformly.
- Exported from `layers/__init__.py`.

### Tests (offline, synthetic)
`tests/layers/test_residual_vq.py` — shapes/dtypes, leading-dim preservation, straight-through identity gradient, EMA-buffer vs trained-parameter codebook, EMA update moves the codebook, dead-code reset (active + no-op paths), non-trivial perplexity, residual-norm reduction with more levels, and input-validation errors. **100% coverage** on the new module.

### Notes
- **No new dependencies** (`torch` already present); `uv.lock` unchanged.
- `make ci` green (black, isort, flake8, mypy strict, pytest).
- Docs updated in this PR: PR #3 marked done in `docs/STATUS.md` / `docs/PROJECT_PLAN.md`, next task set to **PR #4 (VQ-VAE core model, NB/ZINB)**, decisions-log entry added.

Leaving merge to a human reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EzTZ8WPYGeVjf2c1wTDeRU)_