### PR TITLE
feat(models): end-to-end VQ-VAE core (PR #4 slice 2)

### DIFF
--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -257,12 +257,18 @@ src/omvqvae/
 
 ### **Phase 2: Core Model (PRs 4–6)**
 
-#### **PR #4: VQ-VAE Core Model (raw-count, NB/ZINB)**
-- **Scope**: encoder/decoder, count likelihoods, size-factor + covariate
-  conditioning, loss composition (recon + VQ).
+#### **PR #4: VQ-VAE Core Model (raw-count, NB/ZINB) — ✅ DONE**
+- **Scope**: encoder/decoder, count likelihoods, size-factor conditioning, loss
+  composition (recon + VQ).
 - **Files**: `models/vqvae.py`, `models/likelihoods.py`.
-- **Exit criteria**: 2-epoch smoke test on synthetic counts; NB and ZINB heads
-  both train; codebooks are utilized (non-trivial perplexity).
+- **Status**: complete. *Slice 1* (reconstruction likelihoods / decoder heads)
+  merged; *Slice 2* (`OmicsVQVAE` wiring the encoder, `ResidualVQ`, and a
+  `ReconstructionHead` end to end, returning a `VQVAEOutput`) landed in
+  `models/vqvae.py`. v1 is unconditional, so covariates are carried by the data
+  layer but not fed to the model.
+- **Exit criteria** (met): 40-step smoke train on synthetic counts; NB and ZINB
+  heads both train (recon loss decreases); codebooks are utilized (non-trivial
+  perplexity); 100% offline coverage; `make ci` green.
 
 #### **PR #5: Training/Fine-tuning CLI + W&B**
 - **Scope**: OmegaConf config, typer CLI, training loop, W&B tracking, toy
@@ -382,6 +388,7 @@ A running record of decisions so future sessions don't re-litigate them.
 | 2026-06-20 | **Residual VQ = `VectorQuantizer` (one codebook) composed by `ResidualVQ` (stacks N over residuals, default 2).** EMA codebook updates are the default (`ema=True`) with dead-code reset; non-EMA falls back to a gradient-trained codebook + codebook-pull loss. Forward returns a `QuantizerOutput`/`ResidualVQOutput` dataclass bundling quantized vectors, indices, split losses, and perplexity/utilization metrics. | EMA + dead-code reset is the standard collapse-resistant VQ recipe (VQ-VAE-2); the dataclass result keeps the model/training PRs decoupled from the quantizer internals and gives PR #5/#9 their monitoring signals for free. |
 | 2026-06-21 | **Reconstruction heads use the scVI count parameterization** (`models/likelihoods.py`): a softmax over genes gives mean *proportions* (`px_scale`), scaled by the observed library size (size factor) to the NB mean `px_rate`; dispersion is a learned **gene-wise** `theta`. NB/ZINB/Gaussian share one `ReconstructionHead` interface (`forward`/`reconstruction_loss`/`expected_counts`) via a `build_reconstruction_head` factory. | Keeps depth handling inside the model and count statistics intact; one interface lets the model and W&B PRs swap likelihoods without changing call sites. Gene-wise dispersion matches scVI's default and is enough for v1. |
 | 2026-06-21 | **Split PR #4 into slices; do the likelihood heads first, independently of the residual VQ.** PR #3 (residual VQ) was concurrently in flight as PR #24, so this run built `models/likelihoods.py` (no VQ dependency) rather than duplicating or blocking on it; once PR #24 merged, `main` was merged back in. The VQ-VAE core (`models/vqvae.py`) is slice 2 and composes `ResidualVQ` + a `ReconstructionHead`. | Avoids duplicating in-flight work and a docs merge conflict; keeps each run to one coherent, CI-verifiable chunk. |
+| 2026-06-22 | **`OmicsVQVAE` = symmetric MLP encoder/decoder around `ResidualVQ` + a `ReconstructionHead`.** Encoder input is internally `log1p`-transformed for numerical stability; the reconstruction *target* is raw counts for NB/ZINB and `log1p` expression for the Gaussian head. Decoder hidden widths mirror the encoder (`hidden_dims` reversed); the head consumes the final decoder hidden dim. `forward` returns a `VQVAEOutput` composing recon + VQ loss with the per-level codes and codebook metrics. Total loss = `reconstruction_loss + vq.loss` (per-cell-mean recon NLL + mean VQ loss), unweighted in v1. | Keeps depth/normalization handling inside the model and count statistics intact; one symmetric, configurable module covers all three likelihoods. The `VQVAEOutput` bundle hands PR #5 its loss + W&B monitoring signals without coupling to the layer internals. Loss-term weighting is left as a future tuning knob. |
 
 ## 🔄 **Future Roadmap (Post-v1.0)**
 - **Other omics modalities**: extend the discrete-codebook approach beyond
@@ -398,8 +405,8 @@ A running record of decisions so future sessions don't re-litigate them.
 
 ---
 
-**Last Updated**: 2026-06-21 — PR #3 (residual VQ layer, PR #24) merged to `main`;
-PR #4 slice 1 (reconstruction likelihoods) landed.
-**Current Focus**: PR #4 slice 2 — encoder/decoder VQ-VAE core, composing
-`ResidualVQ` + a `ReconstructionHead` (see `docs/STATUS.md`).
-**Next Review**: After PR #4 (VQ-VAE core model).
+**Last Updated**: 2026-06-22 — PR #4 complete: `OmicsVQVAE` (`models/vqvae.py`)
+wires the encoder, `ResidualVQ`, and a `ReconstructionHead` end to end.
+**Current Focus**: PR #5 — training/fine-tuning CLI + W&B tracking (offline-
+friendly tracker + training loop first; see `docs/STATUS.md`).
+**Next Review**: After PR #5 (training CLI + W&B).

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -4,7 +4,7 @@
 > end of every working session** so the next session can pick up cold. Keep it
 > short; deep rationale lives in `docs/PROJECT_PLAN.md`.
 
-**Last updated:** 2026-06-21
+**Last updated:** 2026-06-22
 
 ## Current state
 
@@ -41,7 +41,7 @@
     quantizers over successive residuals; per-level indices = the cell's discrete
     code; summed quantized vectors approximate the input). Per-forward
     perplexity/utilization metrics via `QuantizerOutput` / `ResidualVQOutput`.
-- **PR #4 slice 1 (reconstruction likelihoods) — DONE (this PR).**
+- **PR #4 slice 1 (reconstruction likelihoods) — DONE and merged to `main`.**
   - `models/likelihoods.py`: pure log-prob functions `log_nb_positive`,
     `log_zinb_positive`, `log_gaussian` (SciPy-checked) plus the decoder heads
     `NBHead`, `ZINBHead`, `GaussianHead` behind one `ReconstructionHead`
@@ -49,30 +49,46 @@
     and a `build_reconstruction_head` factory. scVI-style count parameterization
     (softmax `px_scale` × library size → NB mean; gene-wise dispersion). No new
     deps. Offline tests at 100% coverage; `make ci` green.
+- **PR #4 slice 2 (encoder/decoder VQ-VAE core) — DONE (this PR). PR #4 complete.**
+  - `models/vqvae.py`: `OmicsVQVAE` (`nn.Module`) wires the three stages — an
+    MLP encoder (raw counts → internal `log1p` → hidden → `n_latent`), the
+    `ResidualVQ` bottleneck (`omvqvae.layers`), and a mirrored decoder feeding a
+    `ReconstructionHead` (`omvqvae.models.likelihoods`). `forward(counts,
+    size_factors)` returns a `VQVAEOutput` composing recon + VQ loss and exposing
+    the per-level discrete codes, the latent / quantized vectors, and codebook
+    perplexity/utilization. Convenience methods: `encode`, `quantize`,
+    `encode_codes`, `decode`, `expected_counts`. NB/ZINB reconstruct raw counts;
+    the Gaussian head targets `log1p` expression. No new deps. Offline tests at
+    100% coverage incl. a synthetic 40-step smoke-train (NB + ZINB) where the
+    recon loss decreases and codebooks stay utilized; `make ci` green.
 - Plan/docs reflect the pivot: Census streaming, raw-count NB/ZINB modeling,
   discrete universal latent space, human+mouse, v1 unconditional, W&B monitoring.
 
-## Next task — PR #4 slice 2: encoder/decoder VQ-VAE core
+## Next task — PR #5: training/fine-tuning CLI + W&B tracking
 
-The reconstruction heads (slice 1, this PR) and the residual VQ layer (PR #24,
-now in `main`) are the two halves of the bottleneck + output. Slice 2 wires them
-into the model.
+The model core (PR #4) is now complete: data → `OmicsVQVAE` → loss is wired end
+to end. PR #5 turns that into a runnable training entry point.
 
-1. `models/vqvae.py` — an `nn.Module` encoder (raw counts → internal log1p →
-   hidden), the `ResidualVQ` bottleneck (`omvqvae.layers`), and a decoder that
-   feeds a `ReconstructionHead` (`omvqvae.models.likelihoods`). Compose recon + VQ
-   losses; expose codes (per-level indices) and codebook metrics.
-2. Tests (offline, synthetic): a 2-epoch smoke train on synthetic counts for the
-   NB and ZINB heads; loss decreases; codebooks utilized (non-trivial
-   perplexity); shapes/round-trip. Keep `make ci` green.
+1. `utils/tracking.py` — a thin experiment-tracking wrapper around W&B that is
+   **offline-friendly**: a no-op/console logger when W&B is disabled or absent
+   (lazy-import `wandb`), logging losses, reconstruction metrics, and codebook
+   usage/perplexity from `VQVAEOutput`.
+2. `train/loop.py` — a training loop that pulls `Minibatch`es from any data
+   source (local AnnData now; Census), runs `OmicsVQVAE`, steps an optimizer,
+   and logs through the tracker. Keep the heavy/networked I/O thin; test the
+   pure loop on a synthetic in-memory `CountsDataset`.
+3. `train/cli.py` — an OmegaConf + typer CLI to launch training/fine-tuning from
+   a config (organism, data source, model hyper-params, likelihood). Add deps
+   `omegaconf`, `typer`, `rich` (already partly present — verify) and refresh
+   `uv.lock` if needed.
 
-**Unblocked:** both halves now exist (`ResidualVQ` merged in PR #24; the
-likelihood heads in this PR), so slice 2 can be built directly off `main` once
-this PR merges.
+Consider splitting: slice 1 = `tracking.py` + `train/loop.py` (offline-testable,
+no CLI/heavy deps); slice 2 = the typer/OmegaConf CLI. The tracker + loop are the
+coherent first chunk.
 
-**Definition of done:** an end-to-end VQ-VAE that encodes raw counts to discrete
-codes and reconstructs counts via NB/ZINB; a synthetic smoke-train converges;
-offline tests; CI green; PR opened.
+**Definition of done:** a CLI trains a toy model from a local `.h5ad` (and,
+network-gated, from Census) in minutes; runs log to W&B and also work offline;
+offline tests on the pure loop; CI green; PR opened.
 
 ## Open questions / parked
 
@@ -91,6 +107,18 @@ offline tests; CI green; PR opened.
 
 ## Changelog (most recent first)
 
+- **2026-06-22** — PR #4 slice 2: encoder/decoder VQ-VAE core. Added
+  `models/vqvae.py` — `OmicsVQVAE` composing an MLP encoder (raw counts →
+  internal `log1p` → `n_latent`), the `ResidualVQ` bottleneck, and a mirrored
+  decoder feeding a `ReconstructionHead`. `forward(counts, size_factors)`
+  returns a `VQVAEOutput` bundling the composed reconstruction + VQ loss, the
+  per-level discrete codes, latent/quantized vectors, and codebook
+  perplexity/utilization; plus `encode`/`quantize`/`encode_codes`/`decode`/
+  `expected_counts` helpers. NB/ZINB reconstruct raw counts; the Gaussian head
+  targets `log1p` expression. Exported from `models/__init__.py`. No new deps;
+  `uv.lock` unchanged. Offline tests at 100% coverage incl. a synthetic 40-step
+  smoke-train (NB + ZINB) where the reconstruction loss decreases and codebooks
+  stay utilized; `make ci` green. **PR #4 is now complete.**
 - **2026-06-21** — PR #4 slice 1: reconstruction likelihoods. Added
   `models/likelihoods.py` — pure log-prob functions (`log_nb_positive`,
   `log_zinb_positive`, `log_gaussian`, validated against SciPy) and decoder heads

--- a/src/omvqvae/models/__init__.py
+++ b/src/omvqvae/models/__init__.py
@@ -1,7 +1,8 @@
 """VQ-VAE model implementations.
 
-Currently exposes the raw-count reconstruction likelihoods and decoder heads
-(NB / ZINB / Gaussian); the encoder/decoder VQ-VAE itself lands with PR #4.
+Exposes the raw-count reconstruction likelihoods and decoder heads
+(NB / ZINB / Gaussian) and the end-to-end encoder/residual-VQ/decoder
+:class:`OmicsVQVAE`.
 """
 
 from omvqvae.models.likelihoods import (
@@ -15,6 +16,7 @@ from omvqvae.models.likelihoods import (
     log_nb_positive,
     log_zinb_positive,
 )
+from omvqvae.models.vqvae import OmicsVQVAE, VQVAEOutput
 
 __all__ = [
     "LIKELIHOODS",
@@ -26,4 +28,6 @@ __all__ = [
     "ZINBHead",
     "GaussianHead",
     "build_reconstruction_head",
+    "OmicsVQVAE",
+    "VQVAEOutput",
 ]

--- a/src/omvqvae/models/vqvae.py
+++ b/src/omvqvae/models/vqvae.py
@@ -1,0 +1,350 @@
+"""
+End-to-end VQ-VAE model for OQAE.
+
+This module wires the two halves of the discrete bottleneck — the residual
+vector quantizer (:mod:`omvqvae.layers.residual_vq`) and the reconstruction
+heads (:mod:`omvqvae.models.likelihoods`) — into a single
+:class:`torch.nn.Module`:
+
+```
+raw counts ─► (internal log1p) ─► Encoder ─► ResidualVQ ─► Decoder ─► NB/ZINB
+                                              (discrete codes)         params
+```
+
+The model ingests **raw counts** and an observed per-cell **size factor**. An
+internal ``log1p`` transform is applied to the encoder input for numerical
+stability (the raw counts themselves are reconstructed by a count likelihood).
+The encoder maps each cell to a continuous latent vector; the
+:class:`~omvqvae.layers.residual_vq.ResidualVQ` quantizes it to a small set of
+codebook indices — the cell's discrete, universal code — and the decoder maps
+the summed quantized vectors (plus the size factor) to the parameters of the
+reconstruction likelihood.
+
+The forward pass returns a :class:`VQVAEOutput` bundling the composed loss
+(reconstruction + VQ), the per-level codes, and the codebook monitoring metrics
+(perplexity / utilization) so the training and W&B-logging PRs can consume them
+uniformly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Sequence, Tuple
+
+import torch
+from torch import Tensor, nn
+
+from omvqvae.layers.residual_vq import ResidualVQ, ResidualVQOutput
+from omvqvae.models.likelihoods import ReconstructionHead, build_reconstruction_head
+from omvqvae.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+__all__ = [
+    "VQVAEOutput",
+    "OmicsVQVAE",
+]
+
+
+@dataclass
+class VQVAEOutput:
+    """
+    Output of an :class:`OmicsVQVAE` forward pass.
+
+    Attributes
+    ----------
+    loss : torch.Tensor
+        Scalar total loss: reconstruction loss + VQ loss.
+    reconstruction_loss : torch.Tensor
+        Scalar reconstruction loss (negative log-likelihood, summed over genes
+        and reduced over cells).
+    vq_loss : torch.Tensor
+        Scalar VQ loss summed over codebooks (commitment + codebook terms).
+    commitment_loss : torch.Tensor
+        Scalar commitment loss summed over codebooks.
+    codebook_loss : torch.Tensor
+        Scalar codebook loss summed over codebooks (zero under EMA updates).
+    indices : torch.Tensor
+        Per-level codebook indices of shape ``(batch, n_codebooks)``
+        (``int64``); this is each cell's discrete code.
+    latent : torch.Tensor
+        Continuous encoder output of shape ``(batch, n_latent)`` before
+        quantization.
+    quantized : torch.Tensor
+        Summed quantized latent of shape ``(batch, n_latent)``.
+    perplexity : torch.Tensor
+        Scalar mean codebook perplexity across levels.
+    perplexities : torch.Tensor
+        Per-level perplexities of shape ``(n_codebooks,)``.
+    usages : torch.Tensor
+        Per-level codebook utilization of shape ``(n_codebooks,)``.
+    """
+
+    loss: Tensor
+    reconstruction_loss: Tensor
+    vq_loss: Tensor
+    commitment_loss: Tensor
+    codebook_loss: Tensor
+    indices: Tensor
+    latent: Tensor
+    quantized: Tensor
+    perplexity: Tensor
+    perplexities: Tensor
+    usages: Tensor
+
+
+def _build_mlp(
+    in_dim: int, dims: Sequence[int], dropout: float
+) -> Tuple[nn.Sequential, int]:
+    """
+    Build a ``Linear -> ReLU (-> Dropout)`` MLP body.
+
+    Parameters
+    ----------
+    in_dim : int
+        Input dimensionality.
+    dims : Sequence[int]
+        Hidden-layer widths, in order. May be empty (yields an identity body).
+    dropout : float
+        Dropout probability applied after each ReLU; skipped when ``<= 0``.
+
+    Returns
+    -------
+    tuple of (torch.nn.Sequential, int)
+        The MLP body and its output dimensionality (``in_dim`` when ``dims`` is
+        empty).
+    """
+    layers: List[nn.Module] = []
+    prev = in_dim
+    for width in dims:
+        layers.append(nn.Linear(prev, width))
+        layers.append(nn.ReLU())
+        if dropout > 0.0:
+            layers.append(nn.Dropout(dropout))
+        prev = width
+    return nn.Sequential(*layers), prev
+
+
+class OmicsVQVAE(nn.Module):
+    """
+    Encoder / residual-VQ / decoder VQ-VAE over raw single-cell counts.
+
+    The model encodes raw counts to a continuous latent, quantizes it to a set
+    of discrete codes via a :class:`~omvqvae.layers.residual_vq.ResidualVQ`, and
+    decodes the codes back to the parameters of a count (or Gaussian)
+    reconstruction likelihood. The encoder input is internally ``log1p``-
+    transformed for numerical stability; the reconstruction *target* is the raw
+    counts for the NB/ZINB heads and the ``log1p`` expression for the Gaussian
+    head.
+
+    Parameters
+    ----------
+    n_genes : int
+        Number of input/output genes (the organism's feature-space size).
+    n_latent : int, default 16
+        Dimensionality of the latent / codebook vectors.
+    hidden_dims : Sequence[int], default (128,)
+        Encoder hidden-layer widths (``n_genes -> ... -> n_latent``). The decoder
+        mirrors these in reverse. May be empty for a linear encoder/decoder.
+    likelihood : {"nb", "zinb", "gaussian"}, default "nb"
+        Reconstruction likelihood (see
+        :func:`omvqvae.models.likelihoods.build_reconstruction_head`).
+    codebook_size : int, default 256
+        Number of entries in each codebook.
+    n_codebooks : int, default 2
+        Number of residual quantization levels.
+    commitment_cost : float, default 0.25
+        Commitment-loss weight passed to the quantizer.
+    ema : bool, default True
+        Whether codebooks update by EMA (see
+        :class:`~omvqvae.layers.residual_vq.VectorQuantizer`).
+    ema_decay : float, default 0.99
+        EMA decay for the codebooks.
+    reset_dead_codes : bool, default True
+        Whether each codebook resets dead entries (collapse guard).
+    dropout : float, default 0.0
+        Dropout probability in the encoder/decoder MLPs.
+
+    Raises
+    ------
+    ValueError
+        If ``n_genes`` or ``n_latent`` is not positive.
+    """
+
+    def __init__(
+        self,
+        n_genes: int,
+        *,
+        n_latent: int = 16,
+        hidden_dims: Sequence[int] = (128,),
+        likelihood: str = "nb",
+        codebook_size: int = 256,
+        n_codebooks: int = 2,
+        commitment_cost: float = 0.25,
+        ema: bool = True,
+        ema_decay: float = 0.99,
+        reset_dead_codes: bool = True,
+        dropout: float = 0.0,
+    ) -> None:
+        super().__init__()
+        if n_genes < 1:
+            raise ValueError("n_genes must be a positive integer.")
+        if n_latent < 1:
+            raise ValueError("n_latent must be a positive integer.")
+
+        self.n_genes = n_genes
+        self.n_latent = n_latent
+        self.hidden_dims = tuple(hidden_dims)
+        self.likelihood = likelihood.lower()
+
+        # Encoder: counts (log1p) -> hidden MLP -> latent.
+        enc_body, enc_out = _build_mlp(n_genes, self.hidden_dims, dropout)
+        self.encoder_body = enc_body
+        self.to_latent = nn.Linear(enc_out, n_latent)
+
+        # Discrete bottleneck.
+        self.rvq = ResidualVQ(
+            codebook_size=codebook_size,
+            embedding_dim=n_latent,
+            n_codebooks=n_codebooks,
+            commitment_cost=commitment_cost,
+            ema=ema,
+            ema_decay=ema_decay,
+            reset_dead_codes=reset_dead_codes,
+        )
+
+        # Decoder: latent -> hidden MLP (mirror of the encoder) -> head.
+        dec_body, dec_out = _build_mlp(
+            n_latent, tuple(reversed(self.hidden_dims)), dropout
+        )
+        self.decoder_body = dec_body
+        self.head: ReconstructionHead = build_reconstruction_head(
+            self.likelihood, dec_out, n_genes
+        )
+
+    @property
+    def n_codebooks(self) -> int:
+        """Number of residual quantization levels."""
+        return self.rvq.n_codebooks
+
+    def _encoder_input(self, counts: Tensor) -> Tensor:
+        """Internal ``log1p`` transform applied to the encoder input."""
+        return torch.log1p(counts)
+
+    def _recon_target(self, counts: Tensor) -> Tensor:
+        """
+        Reconstruction target for the configured likelihood.
+
+        Raw counts for the count heads (NB/ZINB); ``log1p`` expression for the
+        Gaussian head, which models normalized values rather than counts.
+        """
+        if self.likelihood == "gaussian":
+            return torch.log1p(counts)
+        return counts
+
+    def encode(self, counts: Tensor) -> Tensor:
+        """
+        Encode raw counts to the continuous (pre-quantization) latent.
+
+        Parameters
+        ----------
+        counts : torch.Tensor
+            Raw counts of shape ``(batch, n_genes)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Latent vectors of shape ``(batch, n_latent)``.
+        """
+        hidden = self.encoder_body(self._encoder_input(counts))
+        latent: Tensor = self.to_latent(hidden)
+        return latent
+
+    def quantize(self, latent: Tensor) -> ResidualVQOutput:
+        """Quantize a continuous latent through the residual codebook stack."""
+        out: ResidualVQOutput = self.rvq(latent)
+        return out
+
+    def encode_codes(self, counts: Tensor) -> Tensor:
+        """
+        Encode raw counts to their discrete codes (per-level codebook indices).
+
+        Parameters
+        ----------
+        counts : torch.Tensor
+            Raw counts of shape ``(batch, n_genes)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Codebook indices of shape ``(batch, n_codebooks)`` (``int64``).
+
+        Notes
+        -----
+        In training mode this still updates the EMA codebooks / dead-code
+        statistics; call on a model in ``eval()`` mode for pure inference.
+        """
+        out: ResidualVQOutput = self.rvq(self.encode(counts))
+        return out.indices
+
+    def decode(self, quantized: Tensor, size_factors: Tensor) -> Dict[str, Tensor]:
+        """
+        Decode a quantized latent to the reconstruction-likelihood parameters.
+
+        Parameters
+        ----------
+        quantized : torch.Tensor
+            Quantized latent of shape ``(batch, n_latent)``.
+        size_factors : torch.Tensor
+            Per-cell size factors of shape ``(batch,)``.
+
+        Returns
+        -------
+        Dict[str, torch.Tensor]
+            The per-gene distribution parameters (see the configured head).
+        """
+        params: Dict[str, Tensor] = self.head(
+            self.decoder_body(quantized), size_factors
+        )
+        return params
+
+    def expected_counts(self, quantized: Tensor, size_factors: Tensor) -> Tensor:
+        """Return the reconstruction mean for a quantized latent."""
+        return self.head.expected_counts(self.decoder_body(quantized), size_factors)
+
+    def forward(self, counts: Tensor, size_factors: Tensor) -> VQVAEOutput:
+        """
+        Encode, quantize, decode, and compose the loss for a batch.
+
+        Parameters
+        ----------
+        counts : torch.Tensor
+            Raw counts of shape ``(batch, n_genes)``.
+        size_factors : torch.Tensor
+            Per-cell size factors of shape ``(batch,)``.
+
+        Returns
+        -------
+        VQVAEOutput
+            Composed loss, discrete codes, and codebook monitoring metrics.
+        """
+        latent = self.encode(counts)
+        vq: ResidualVQOutput = self.rvq(latent)
+        hidden = self.decoder_body(vq.quantized)
+        recon_loss = self.head.reconstruction_loss(
+            hidden, self._recon_target(counts), size_factors, reduction="mean"
+        )
+        total_loss = recon_loss + vq.loss
+        return VQVAEOutput(
+            loss=total_loss,
+            reconstruction_loss=recon_loss,
+            vq_loss=vq.loss,
+            commitment_loss=vq.commitment_loss,
+            codebook_loss=vq.codebook_loss,
+            indices=vq.indices,
+            latent=latent,
+            quantized=vq.quantized,
+            perplexity=vq.perplexity,
+            perplexities=vq.perplexities,
+            usages=vq.usages,
+        )

--- a/tests/models/test_vqvae.py
+++ b/tests/models/test_vqvae.py
@@ -1,0 +1,207 @@
+"""Tests for the end-to-end OQAE VQ-VAE model.
+
+Offline and synthetic: construction/validation, shape and round-trip
+invariants, gradient flow through the discrete bottleneck, and a short
+smoke-train on synthetic counts (NB and ZINB) checking that the loss decreases
+and the codebooks stay utilized.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+
+from omvqvae.models.vqvae import OmicsVQVAE, VQVAEOutput
+
+
+def _synthetic_counts(
+    n_cells: int, n_genes: int, *, seed: int = 0
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Draw a small synthetic raw-count batch and its size factors."""
+    rng = np.random.default_rng(seed)
+    # Two latent "cell types" with distinct mean expression so structure exists.
+    means = rng.gamma(shape=2.0, scale=1.0, size=(2, n_genes))
+    assignments = rng.integers(0, 2, size=n_cells)
+    rates = means[assignments]
+    counts = rng.poisson(rates).astype(np.float32)
+    counts_t = torch.from_numpy(counts)
+    size_factors = counts_t.sum(dim=1).clamp(min=1.0)
+    return counts_t, size_factors
+
+
+# --------------------------------------------------------------------------- #
+# Construction / validation
+# --------------------------------------------------------------------------- #
+def test_invalid_dimensions_raise() -> None:
+    with pytest.raises(ValueError):
+        OmicsVQVAE(0)
+    with pytest.raises(ValueError):
+        OmicsVQVAE(10, n_latent=0)
+
+
+def test_unknown_likelihood_raises() -> None:
+    with pytest.raises(ValueError):
+        OmicsVQVAE(10, likelihood="poisson")
+
+
+@pytest.mark.parametrize("hidden_dims", [(), (32,), (64, 32)])
+def test_encoder_decoder_shapes(hidden_dims: tuple[int, ...]) -> None:
+    model = OmicsVQVAE(
+        12, n_latent=8, hidden_dims=hidden_dims, codebook_size=16, n_codebooks=3
+    )
+    counts, size_factors = _synthetic_counts(5, 12)
+
+    latent = model.encode(counts)
+    assert latent.shape == (5, 8)
+
+    out = model(counts, size_factors)
+    assert isinstance(out, VQVAEOutput)
+    assert out.indices.shape == (5, 3)
+    assert out.indices.dtype == torch.int64
+    assert out.quantized.shape == (5, 8)
+    assert out.latent.shape == (5, 8)
+    assert out.perplexities.shape == (3,)
+    assert out.usages.shape == (3,)
+    assert model.n_codebooks == 3
+
+
+def test_loss_composition_and_scalars() -> None:
+    model = OmicsVQVAE(10, n_latent=8, hidden_dims=(16,), codebook_size=16)
+    counts, size_factors = _synthetic_counts(6, 10)
+
+    out = model(counts, size_factors)
+    for scalar in (
+        out.loss,
+        out.reconstruction_loss,
+        out.vq_loss,
+        out.commitment_loss,
+        out.codebook_loss,
+        out.perplexity,
+    ):
+        assert scalar.ndim == 0
+    # Total loss is reconstruction + VQ loss.
+    torch.testing.assert_close(out.loss, out.reconstruction_loss + out.vq_loss)
+    # EMA is on by default, so the codebook-pull term is dropped.
+    torch.testing.assert_close(out.codebook_loss, torch.zeros(()))
+
+
+# --------------------------------------------------------------------------- #
+# Codes / round-trip
+# --------------------------------------------------------------------------- #
+def test_encode_codes_matches_forward_indices() -> None:
+    model = OmicsVQVAE(10, n_latent=8, hidden_dims=(16,), codebook_size=16)
+    model.eval()  # avoid EMA/dead-code updates between the two calls
+    counts, _ = _synthetic_counts(4, 10)
+
+    codes = model.encode_codes(counts)
+    assert codes.shape == (4, model.n_codebooks)
+    assert codes.dtype == torch.int64
+    assert int(codes.min()) >= 0
+    assert int(codes.max()) < 16
+
+
+def test_expected_counts_shape_and_nonnegative_for_nb() -> None:
+    model = OmicsVQVAE(10, n_latent=8, hidden_dims=(16,), likelihood="nb")
+    model.eval()
+    counts, size_factors = _synthetic_counts(4, 10)
+
+    out = model(counts, size_factors)
+    expected = model.expected_counts(out.quantized, size_factors)
+    assert expected.shape == (4, 10)
+    assert torch.all(expected >= 0.0)
+
+
+def test_decode_params_for_zinb() -> None:
+    model = OmicsVQVAE(10, n_latent=8, hidden_dims=(16,), likelihood="zinb")
+    model.eval()
+    counts, size_factors = _synthetic_counts(4, 10)
+
+    out = model(counts, size_factors)
+    params = model.decode(out.quantized, size_factors)
+    assert set(params) >= {"px_scale", "px_rate", "theta", "zi_logits"}
+    assert params["zi_logits"].shape == (4, 10)
+
+
+def test_gaussian_head_targets_log1p_expression() -> None:
+    # The Gaussian head reconstructs log1p expression rather than raw counts.
+    model = OmicsVQVAE(10, n_latent=8, hidden_dims=(16,), likelihood="gaussian")
+    counts, size_factors = _synthetic_counts(5, 10)
+
+    torch.testing.assert_close(model._recon_target(counts), torch.log1p(counts))
+    out = model(counts, size_factors)
+    assert out.loss.ndim == 0
+    params = model.decode(out.quantized, size_factors)
+    assert set(params) == {"mean", "log_var"}
+
+
+def test_quantize_method_matches_forward() -> None:
+    model = OmicsVQVAE(10, n_latent=8, hidden_dims=(16,), codebook_size=16)
+    model.eval()
+    counts, _ = _synthetic_counts(4, 10)
+
+    latent = model.encode(counts)
+    vq = model.quantize(latent)
+    torch.testing.assert_close(vq.indices, model.rvq(latent).indices)
+
+
+def test_dropout_layers_present() -> None:
+    model = OmicsVQVAE(10, n_latent=8, hidden_dims=(16,), dropout=0.5)
+    has_dropout = any(
+        isinstance(m, torch.nn.Dropout) for m in model.encoder_body.modules()
+    )
+    assert has_dropout
+
+
+# --------------------------------------------------------------------------- #
+# Gradient flow
+# --------------------------------------------------------------------------- #
+def test_gradients_flow_through_bottleneck() -> None:
+    model = OmicsVQVAE(10, n_latent=8, hidden_dims=(16,), codebook_size=16)
+    counts, size_factors = _synthetic_counts(6, 10)
+
+    out = model(counts, size_factors)
+    out.loss.backward()
+
+    # The straight-through estimator must carry gradient back to the encoder.
+    grad = model.to_latent.weight.grad
+    assert grad is not None
+    assert torch.any(grad != 0.0)
+
+
+# --------------------------------------------------------------------------- #
+# Smoke train
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("likelihood", ["nb", "zinb"])
+def test_smoke_train_converges(likelihood: str) -> None:
+    torch.manual_seed(0)
+    counts, size_factors = _synthetic_counts(64, 20, seed=1)
+    model = OmicsVQVAE(
+        20,
+        n_latent=8,
+        hidden_dims=(32,),
+        likelihood=likelihood,
+        codebook_size=32,
+        n_codebooks=2,
+    )
+    optimizer = torch.optim.Adam(model.parameters(), lr=1e-2)
+
+    model.train()
+    first_loss = None
+    last_loss = None
+    for _ in range(40):
+        optimizer.zero_grad()
+        out = model(counts, size_factors)
+        out.loss.backward()
+        optimizer.step()
+        if first_loss is None:
+            first_loss = out.reconstruction_loss.item()
+        last_loss = out.reconstruction_loss.item()
+
+    assert first_loss is not None and last_loss is not None
+    # Reconstruction improves over the short run.
+    assert last_loss < first_loss
+    # Codebooks are non-trivially utilized (no collapse to a single code).
+    model.eval()
+    final = model(counts, size_factors)
+    assert float(final.perplexity) > 1.0


### PR DESCRIPTION
## Summary

Completes **PR #4** by wiring the two halves of the discrete bottleneck — the
residual vector quantizer (PR #3) and the reconstruction heads (PR #4 slice 1) —
into an end-to-end model in `models/vqvae.py`.

```
raw counts ─► (internal log1p) ─► Encoder ─► ResidualVQ ─► Decoder ─► NB/ZINB
                                              (discrete codes)         params
```

### `OmicsVQVAE`
- **Encoder**: MLP `n_genes → hidden_dims → n_latent`; input internally
  `log1p`-transformed for numerical stability.
- **Bottleneck**: `ResidualVQ` (`omvqvae.layers`) quantizes the latent to a set
  of per-level codebook indices — the cell's discrete code.
- **Decoder**: hidden MLP mirroring the encoder, feeding a `ReconstructionHead`
  (`omvqvae.models.likelihoods`). NB/ZINB reconstruct **raw counts**; the
  Gaussian head targets **`log1p` expression**.
- `forward(counts, size_factors)` returns a **`VQVAEOutput`** composing
  reconstruction + VQ loss and exposing the per-level codes, latent/quantized
  vectors, and codebook perplexity/utilization.
- Convenience methods: `encode`, `quantize`, `encode_codes`, `decode`,
  `expected_counts`.

### Design notes
- Total loss = per-cell-mean reconstruction NLL + mean VQ loss (unweighted in
  v1; weighting left as a future tuning knob).
- v1 is unconditional — covariates travel with the data layer but are not fed to
  the model.

### Tests (offline, synthetic)
- Construction/validation, encoder/decoder shapes across `hidden_dims` variants,
  loss composition, round-trip codes, gradient flow through the straight-through
  bottleneck.
- A 40-step **smoke-train** (NB + ZINB) where the reconstruction loss decreases
  and codebooks stay utilized (non-trivial perplexity).
- New module at **100% coverage**; `make ci` green (black, isort, flake8, mypy
  strict, pytest). No new dependencies.

### Docs
- `docs/STATUS.md`: PR #4 marked complete; new **Next task = PR #5** (training
  CLI + W&B); changelog updated.
- `docs/PROJECT_PLAN.md`: PR #4 marked ✅ DONE; decision-log row for the model
  design; footer/focus updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0114gCRzXMjkem4EL2V6mLrC)_