### PR TITLE
feat(train): config-driven training CLI (PR #5 slice 2)

### DIFF
--- a/configs/train_toy.yaml
+++ b/configs/train_toy.yaml
@@ -1,0 +1,47 @@
+# Toy training configuration for the OQAE CLI.
+#
+# Run with:
+#   oqae-train configs/train_toy.yaml -s data.path=/path/to/cells.h5ad
+#
+# All values below are merged onto the typed defaults in
+# `omvqvae.train.cli.ExperimentConfig`; only override what you need. Point
+# `data.path` at a local `.h5ad` / `.zarr` of raw counts (the reference gene
+# vocabulary is derived from that file's genes).
+
+seed: 0
+
+model:
+  n_latent: 16
+  hidden_dims: [64]
+  likelihood: nb        # nb | zinb | gaussian
+  codebook_size: 64
+  n_codebooks: 2
+  commitment_cost: 0.25
+  ema: true
+  ema_decay: 0.99
+  reset_dead_codes: true
+  dropout: 0.0
+
+data:
+  source: anndata       # anndata | census
+  organism: homo_sapiens
+  path: null            # <-- set this (e.g. via `-s data.path=...`)
+  batch_size: 128
+  shuffle: true
+  size_factor_mode: total
+
+training:
+  max_epochs: 5
+  lr: 1.0e-3
+  weight_decay: 0.0
+  grad_clip_norm: 1.0
+  max_steps: null
+  log_every: 10
+  device: cpu
+  checkpoint_path: null # set to write `{state_dict, gene_ids, config}` after training
+
+tracking:
+  backend: console      # console | none | wandb
+  run_name: oqae-toy
+  project: oqae
+  offline: false

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -277,11 +277,19 @@ src/omvqvae/
   schemas.
 - **Exit criteria**: CLI trains a toy model from Census *and* from a local
   `.h5ad` in minutes; runs log to W&B (and work offline).
-- **Status**: slice 1 **DONE** — `utils/tracking.py` (offline-friendly
+- **Status**: **DONE**. Slice 1 — `utils/tracking.py` (offline-friendly
   `ExperimentTracker`/`ConsoleTracker`/`WandbTracker`/`build_tracker` +
   `vqvae_metrics`) and `train/loop.py` (`train` + `TrainConfig`/`EpochMetrics`/
-  `TrainResult`, source-agnostic over any `Minibatch` iterable). Slice 2 (the
-  typer/OmegaConf CLI in `train/cli.py`) is next.
+  `TrainResult`, source-agnostic over any `Minibatch` iterable). Slice 2 —
+  `train/cli.py`: an OmegaConf-validated config schema (`ExperimentConfig` and
+  per-section dataclasses) + a typer `oqae-train` entry point. Pure builders map
+  each config section to an object (`build_model`, `build_train_config`,
+  `build_tracker_from_config`, `build_data`); `run_experiment` wires them and
+  calls `train`. Local-AnnData source derives its `GeneVocabulary` from the
+  file's genes; the Census source is gated/`# pragma: no cover`. Optional
+  checkpoint persists `{state_dict, organism, gene_ids, config}`. Ships
+  `configs/train_toy.yaml`; offline tests cover loading/builders/wiring and the
+  Typer `CliRunner` end-to-end.
 
 #### **PR #6: HuggingFace Hub Integration**
 - **Scope**: serialize/deserialize model + codebooks + config; push/pull.
@@ -394,6 +402,7 @@ A running record of decisions so future sessions don't re-litigate them.
 | 2026-06-21 | **Reconstruction heads use the scVI count parameterization** (`models/likelihoods.py`): a softmax over genes gives mean *proportions* (`px_scale`), scaled by the observed library size (size factor) to the NB mean `px_rate`; dispersion is a learned **gene-wise** `theta`. NB/ZINB/Gaussian share one `ReconstructionHead` interface (`forward`/`reconstruction_loss`/`expected_counts`) via a `build_reconstruction_head` factory. | Keeps depth handling inside the model and count statistics intact; one interface lets the model and W&B PRs swap likelihoods without changing call sites. Gene-wise dispersion matches scVI's default and is enough for v1. |
 | 2026-06-21 | **Split PR #4 into slices; do the likelihood heads first, independently of the residual VQ.** PR #3 (residual VQ) was concurrently in flight as PR #24, so this run built `models/likelihoods.py` (no VQ dependency) rather than duplicating or blocking on it; once PR #24 merged, `main` was merged back in. The VQ-VAE core (`models/vqvae.py`) is slice 2 and composes `ResidualVQ` + a `ReconstructionHead`. | Avoids duplicating in-flight work and a docs merge conflict; keeps each run to one coherent, CI-verifiable chunk. |
 | 2026-06-22 | **`OmicsVQVAE` = symmetric MLP encoder/decoder around `ResidualVQ` + a `ReconstructionHead`.** Encoder input is internally `log1p`-transformed for numerical stability; the reconstruction *target* is raw counts for NB/ZINB and `log1p` expression for the Gaussian head. Decoder hidden widths mirror the encoder (`hidden_dims` reversed); the head consumes the final decoder hidden dim. `forward` returns a `VQVAEOutput` composing recon + VQ loss with the per-level codes and codebook metrics. Total loss = `reconstruction_loss + vq.loss` (per-cell-mean recon NLL + mean VQ loss), unweighted in v1. | Keeps depth/normalization handling inside the model and count statistics intact; one symmetric, configurable module covers all three likelihoods. The `VQVAEOutput` bundle hands PR #5 its loss + W&B monitoring signals without coupling to the layer internals. Loss-term weighting is left as a future tuning knob. |
+| 2026-06-24 | **Training CLI = OmegaConf structured config + a single-command typer app (`oqae-train`).** The config schema is plain dataclasses (`ExperimentConfig`/`ModelConfig`/`DataConfig`/`TrainingConfig`/`TrackingConfig`) so OmegaConf validates the YAML, rejects unknown keys, and supports `--set a.b=c` dot-list overrides; `OmegaConf.to_object` yields typed objects for mypy. Pure builders (`build_model`/`build_train_config`/`build_tracker_from_config`/`build_data`) map one config section → one object and `run_experiment` wires them, so the config→objects path is unit-tested offline. The **local-AnnData** source derives its `GeneVocabulary` (hence the model's `n_genes`) from the file's own genes; the **Census** source is the one networked branch (`# pragma: no cover`). The optional checkpoint stores `{state_dict, organism, gene_ids, config}`. | A declarative, schema-checked config keeps runs reproducible and overridable from the shell; the pure-builder split keeps the heavy/networked I/O at the edges and everything else offline-testable (incl. via Typer's `CliRunner`). Persisting `gene_ids`/`organism`/`config` alongside the weights is what PR #6 (HF Hub) and PR #7 (inference) need to reload a model against the right feature space. Single-command typer means `oqae-train config.yaml` with no redundant subcommand name. |
 
 ## 🔄 **Future Roadmap (Post-v1.0)**
 - **Other omics modalities**: extend the discrete-codebook approach beyond

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -4,7 +4,7 @@
 > end of every working session** so the next session can pick up cold. Keep it
 > short; deep rationale lives in `docs/PROJECT_PLAN.md`.
 
-**Last updated:** 2026-06-23
+**Last updated:** 2026-06-24
 
 ## Current state
 
@@ -61,7 +61,25 @@
     the Gaussian head targets `log1p` expression. No new deps. Offline tests at
     100% coverage incl. a synthetic 40-step smoke-train (NB + ZINB) where the
     recon loss decreases and codebooks stay utilized; `make ci` green.
-- **PR #5 slice 1 (tracker + training loop) — DONE (this run).**
+- **PR #5 (training/fine-tuning CLI + W&B) — DONE (both slices). PR #5 complete.**
+  - Slice 2 (this run): `train/cli.py` — a config-driven entry point on top of
+    the loop. An OmegaConf **structured config** (`ExperimentConfig` +
+    `ModelConfig`/`DataConfig`/`TrainingConfig`/`TrackingConfig` dataclasses)
+    validates a YAML, rejects unknown keys, and takes `--set a.b=c` overrides.
+    Pure builders map each section to an object (`build_model`,
+    `build_train_config`, `build_tracker_from_config`, `build_data`);
+    `run_experiment` wires them and calls `omvqvae.train.train`. The
+    local-`.h5ad`/`.zarr` source derives its `GeneVocabulary` (and the model's
+    `n_genes`) from the file's own genes; the Census source is the one networked
+    branch (`# pragma: no cover`). Optional checkpoint persists
+    `{state_dict, organism, gene_ids, config}`. A single-command typer app is
+    exposed as the `oqae-train` console script (added to `pyproject.toml`).
+    Shipped `configs/train_toy.yaml`. All CLI deps
+    (`omegaconf`/`typer`/`rich`/`wandb`) were already declared → **no `uv.lock`
+    change**. Offline tests cover config loading, each builder, `run_experiment`
+    wiring against a synthetic `.h5ad`, and the Typer `CliRunner` end-to-end;
+    `make ci` green (~99% coverage).
+- **PR #5 slice 1 (tracker + training loop) — DONE.**
   - `utils/tracking.py`: an offline-friendly `ExperimentTracker` (ABC) with a
     `ConsoleTracker` default (logs metrics through the OQAE logger; no `wandb`
     needed) and a `WandbTracker` thin shell over an injected live run. The lazy
@@ -81,41 +99,40 @@
 - Plan/docs reflect the pivot: Census streaming, raw-count NB/ZINB modeling,
   discrete universal latent space, human+mouse, v1 unconditional, W&B monitoring.
 
-## Next task — PR #5 slice 2: training/fine-tuning CLI
+## Next task — PR #6: HuggingFace Hub integration
 
-Slice 1 (tracker + training loop) is **DONE** (this run). Slice 2 wires a
-config-driven entry point on top of the loop:
+PR #5 is **DONE**. Next is serializing/round-tripping a trained model through the
+HuggingFace Hub:
 
-1. `train/cli.py` — an OmegaConf + typer CLI to launch training/fine-tuning from
-   a config (organism, data source, model hyper-params, likelihood, tracking
-   backend). All needed deps (`omegaconf`, `typer`, `rich`, `wandb`) are
-   **already in `pyproject.toml`** — verified this run — so no `uv.lock` refresh
-   is expected unless a new dep is introduced.
-2. Build a model from the config (`OmicsVQVAE`), build the data source from the
-   config (local `.h5ad`/`.zarr` via `build_anndata_dataloader` now;
-   Census-gated path optional), build a tracker via
-   `omvqvae.utils.tracking.build_tracker`, and call
-   `omvqvae.train.train(model, loader, config=TrainConfig(...), tracker=...)`.
-3. Ship an example config (e.g. `configs/train_toy.yaml`) and a tiny synthetic
-   `.h5ad` fixture (or generate one in a test) so the CLI is exercised offline.
+1. `models/hf_utils.py` (or `inference/hf_utils.py`) — save a trained
+   `OmicsVQVAE` (state dict + codebooks) **plus** the config and the gene
+   vocabulary (`organism`, `gene_ids`) to a local directory, and load it back to
+   a fully-reconstructed model on the right feature space. The CLI checkpoint
+   already persists `{state_dict, organism, gene_ids, config}` — reuse that
+   bundle shape so a CLI-trained checkpoint and an HF-pushed model share one
+   format.
+2. `push_to_hub` / `from_pretrained`-style helpers wrapping `huggingface_hub`
+   (new dep — add it **only in this PR** and refresh `uv.lock`). Keep the network
+   I/O in a thin shell (`# pragma: no cover`, `@pytest.mark.network`); test the
+   pure save/load round-trip offline against a temp dir.
 
-**Definition of done:** a CLI trains a toy model from a local `.h5ad` (and,
-network-gated, from Census) in minutes; runs log to W&B and also work offline;
-offline tests on the CLI's config→objects wiring (invoke via typer's
-`CliRunner`); CI green; PR opened.
+**Definition of done:** a trained model round-trips state+codebooks+config+vocab
+through a local dir (offline test) and, network-gated, through a HF test repo;
+loading rebuilds the exact model/feature space; CI green; PR opened.
 
-### Available building blocks (slice 1, this run)
+### Available building blocks
 
-- `omvqvae.utils.tracking`: `ExperimentTracker` (ABC), `ConsoleTracker`
-  (offline default, logs via the OQAE logger), `WandbTracker` (wraps an
-  injected live run), `build_tracker(backend=...)` (lazy `wandb.init` lives in
-  `_init_wandb_run`), and `vqvae_metrics(output, prefix=...)` flattening a
-  `VQVAEOutput` to `{name: float}`.
-- `omvqvae.train`: `train(model, data_source, *, config, optimizer, tracker)`
-  plus `TrainConfig` / `EpochMetrics` / `TrainResult`. Source-agnostic: pass any
-  iterable of `Minibatch` (a `DataLoader` for multi-epoch). `TrainConfig`
-  carries `max_epochs`/`lr`/`weight_decay`/`grad_clip_norm`/`max_steps`/
-  `log_every`/`device`.
+- `omvqvae.train`: `run_experiment(config)` / `load_config(path, overrides=...)`
+  / `build_model` / `build_data` / `build_train_config` /
+  `build_tracker_from_config`, plus the `ExperimentConfig` dataclass schema and
+  the `oqae-train` console script. The CLI's optional checkpoint
+  (`training.checkpoint_path`) already writes
+  `torch.save({state_dict, organism, gene_ids, config})` — the natural seed for
+  the HF serialization format.
+- `omvqvae.utils.tracking`: `ExperimentTracker`/`ConsoleTracker`/`WandbTracker`/
+  `build_tracker` + `vqvae_metrics`.
+- `omvqvae.train.loop`: `train(model, data_source, *, config, optimizer,
+  tracker)` + `TrainConfig`/`EpochMetrics`/`TrainResult`.
 
 ## Open questions / parked
 
@@ -134,6 +151,20 @@ offline tests on the CLI's config→objects wiring (invoke via typer's
 
 ## Changelog (most recent first)
 
+- **2026-06-24** — PR #5 slice 2: config-driven training CLI. Added
+  `train/cli.py` — an OmegaConf structured-config schema (`ExperimentConfig` +
+  `ModelConfig`/`DataConfig`/`TrainingConfig`/`TrackingConfig`) and a
+  single-command typer app exposed as the `oqae-train` console script. Pure
+  builders (`build_model`, `build_train_config`, `build_tracker_from_config`,
+  `build_data`) map config sections to objects; `run_experiment` wires them and
+  calls `omvqvae.train.train`. Local-AnnData source derives its `GeneVocabulary`
+  from the file's genes; the Census source is the one gated/`# pragma: no cover`
+  branch. Optional checkpoint persists `{state_dict, organism, gene_ids,
+  config}`. Shipped `configs/train_toy.yaml`; registered `[project.scripts]
+  oqae-train`. All CLI deps were already declared → **`uv.lock` unchanged**.
+  Offline tests cover config loading/validation, every builder, `run_experiment`
+  against a synthetic `.h5ad`, and the Typer `CliRunner` end-to-end; `make ci`
+  green (~99% coverage). **PR #5 is now complete.**
 - **2026-06-23** — PR #5 slice 1: experiment tracker + training loop. Added
   `utils/tracking.py` (`ExperimentTracker` ABC, `ConsoleTracker`,
   `WandbTracker`, `build_tracker`, `vqvae_metrics`) — offline by default

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,9 @@ dev = [
     "coverage>=7.3.0",
 ]
 
+[project.scripts]
+oqae-train = "omvqvae.train.cli:main"
+
 [project.urls]
 Homepage = "https://github.com/mengerj/oqae"
 Repository = "https://github.com/mengerj/oqae.git"

--- a/src/omvqvae/train/__init__.py
+++ b/src/omvqvae/train/__init__.py
@@ -2,14 +2,45 @@
 
 Exposes the source-agnostic training loop (:func:`train`) and its configuration
 / result bundles (:class:`TrainConfig`, :class:`EpochMetrics`,
-:class:`TrainResult`).
+:class:`TrainResult`), plus the config-driven CLI (:func:`run_experiment`,
+:class:`ExperimentConfig`, :func:`load_config`, and the Typer ``app``).
 """
 
+from omvqvae.train.cli import (
+    DataConfig,
+    ExperimentConfig,
+    ModelConfig,
+    TrackingConfig,
+    TrainingConfig,
+    app,
+    build_data,
+    build_model,
+    build_tracker_from_config,
+    build_train_config,
+    load_config,
+    main,
+    run_experiment,
+)
 from omvqvae.train.loop import EpochMetrics, TrainConfig, TrainResult, train
 
 __all__ = [
+    # training loop
     "TrainConfig",
     "EpochMetrics",
     "TrainResult",
     "train",
+    # CLI / config-driven entry point
+    "ModelConfig",
+    "DataConfig",
+    "TrainingConfig",
+    "TrackingConfig",
+    "ExperimentConfig",
+    "load_config",
+    "build_model",
+    "build_train_config",
+    "build_tracker_from_config",
+    "build_data",
+    "run_experiment",
+    "app",
+    "main",
 ]

--- a/src/omvqvae/train/cli.py
+++ b/src/omvqvae/train/cli.py
@@ -1,0 +1,517 @@
+"""
+Config-driven command-line interface for training / fine-tuning OQAE models.
+
+This module turns a declarative configuration (YAML, parsed with OmegaConf) into
+the concrete objects the training loop needs — an
+:class:`~omvqvae.models.vqvae.OmicsVQVAE`, a data source yielding
+:class:`~omvqvae.data.dataset.Minibatch` batches, and an
+:class:`~omvqvae.utils.tracking.ExperimentTracker` — and then runs
+:func:`omvqvae.train.loop.train`.
+
+Design follows the project's "pure core + thin I/O shell" convention:
+
+- The **config schema** is a set of plain dataclasses (:class:`ExperimentConfig`
+  and friends) so OmegaConf can validate/merge a user YAML against typed
+  defaults, and so the wiring is fully typed for mypy.
+- The **builders** (:func:`build_model`, :func:`build_train_config`,
+  :func:`build_tracker`, :func:`build_data`) are small pure functions mapping a
+  config section to one object; they are unit-testable offline.
+- The networked piece — streaming from the CELLxGENE Census — is isolated in one
+  branch of :func:`build_data` and marked ``# pragma: no cover``; the local
+  AnnData path is exercised end-to-end offline (including via Typer's
+  ``CliRunner``).
+
+A console entry point ``oqae-train`` is exposed through :func:`main`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple, cast
+
+from omegaconf import OmegaConf
+
+from omvqvae.train.loop import TrainConfig
+from omvqvae.train.loop import train as run_train
+from omvqvae.utils.logging import get_logger
+from omvqvae.utils.tracking import ExperimentTracker, build_tracker
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from omvqvae.data.dataset import GeneVocabulary, Minibatch
+    from omvqvae.models.vqvae import OmicsVQVAE
+    from omvqvae.train.loop import TrainResult
+
+logger = get_logger(__name__)
+
+__all__ = [
+    "ModelConfig",
+    "DataConfig",
+    "TrainingConfig",
+    "TrackingConfig",
+    "ExperimentConfig",
+    "load_config",
+    "build_model",
+    "build_train_config",
+    "build_tracker_from_config",
+    "build_data",
+    "run_experiment",
+    "app",
+    "main",
+]
+
+
+# --------------------------------------------------------------------------- #
+# Config schema
+# --------------------------------------------------------------------------- #
+@dataclass
+class ModelConfig:
+    """:class:`~omvqvae.models.vqvae.OmicsVQVAE` hyper-parameters.
+
+    ``n_genes`` is left unset (``None``) here because the feature-space size is
+    determined by the data source's :class:`GeneVocabulary`; set it explicitly
+    only to assert/override the expected gene-space size.
+    """
+
+    n_genes: Optional[int] = None
+    n_latent: int = 16
+    hidden_dims: List[int] = field(default_factory=lambda: [128])
+    likelihood: str = "nb"
+    codebook_size: int = 256
+    n_codebooks: int = 2
+    commitment_cost: float = 0.25
+    ema: bool = True
+    ema_decay: float = 0.99
+    reset_dead_codes: bool = True
+    dropout: float = 0.0
+
+
+@dataclass
+class DataConfig:
+    """Data-source configuration.
+
+    ``source`` selects between a local AnnData file (``"anndata"``) and CELLxGENE
+    Census streaming (``"census"``). Fields not relevant to the chosen source are
+    ignored.
+    """
+
+    source: str = "anndata"
+    organism: str = "homo_sapiens"
+    # Local AnnData (`source == "anndata"`).
+    path: Optional[str] = None
+    layer: Optional[str] = None
+    var_key: Optional[str] = None
+    # Census streaming (`source == "census"`).
+    census_version: Optional[str] = None
+    obs_value_filter: Optional[str] = None
+    var_value_filter: Optional[str] = None
+    # Shared loader knobs.
+    batch_size: int = 128
+    shuffle: bool = False
+    num_workers: int = 0
+    batch_key: Optional[str] = None
+    size_factor_mode: str = "total"
+    min_overlap: float = 0.0
+
+
+@dataclass
+class TrainingConfig:
+    """Training-loop knobs (mirror of :class:`omvqvae.train.loop.TrainConfig`)."""
+
+    max_epochs: int = 1
+    lr: float = 1e-3
+    weight_decay: float = 0.0
+    grad_clip_norm: Optional[float] = None
+    max_steps: Optional[int] = None
+    log_every: int = 10
+    device: str = "cpu"
+    checkpoint_path: Optional[str] = None
+
+
+@dataclass
+class TrackingConfig:
+    """Experiment-tracking configuration."""
+
+    backend: str = "console"
+    run_name: Optional[str] = None
+    project: Optional[str] = None
+    offline: bool = False
+
+
+@dataclass
+class ExperimentConfig:
+    """Top-level training configuration."""
+
+    seed: Optional[int] = 0
+    model: ModelConfig = field(default_factory=ModelConfig)
+    data: DataConfig = field(default_factory=DataConfig)
+    training: TrainingConfig = field(default_factory=TrainingConfig)
+    tracking: TrackingConfig = field(default_factory=TrackingConfig)
+
+
+# --------------------------------------------------------------------------- #
+# Config loading
+# --------------------------------------------------------------------------- #
+def load_config(
+    path: Optional[Path] = None,
+    *,
+    overrides: Optional[List[str]] = None,
+) -> ExperimentConfig:
+    """Load and validate an :class:`ExperimentConfig`.
+
+    The typed defaults are merged with the user's YAML (if any) and then with
+    dot-list overrides (e.g. ``["training.lr=1e-2", "model.n_latent=8"]``), so
+    every value is schema-checked and unknown keys are rejected.
+
+    Parameters
+    ----------
+    path : pathlib.Path, optional
+        Path to a YAML config file. When ``None``, only defaults + ``overrides``
+        are used.
+    overrides : List[str], optional
+        OmegaConf dot-list overrides applied last (highest precedence).
+
+    Returns
+    -------
+    ExperimentConfig
+        The fully-resolved, typed configuration.
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``path`` is given but does not exist.
+    """
+    schema = OmegaConf.structured(ExperimentConfig)
+    merged = schema
+    if path is not None:
+        p = Path(path)
+        if not p.exists():
+            raise FileNotFoundError(f"Config file does not exist: {p}")
+        merged = OmegaConf.merge(merged, OmegaConf.load(p))
+    if overrides:
+        merged = OmegaConf.merge(merged, OmegaConf.from_dotlist(list(overrides)))
+    return cast(ExperimentConfig, OmegaConf.to_object(merged))
+
+
+# --------------------------------------------------------------------------- #
+# Builders (config section -> object)
+# --------------------------------------------------------------------------- #
+def build_model(config: ModelConfig, *, n_genes: int) -> "OmicsVQVAE":
+    """Construct an :class:`~omvqvae.models.vqvae.OmicsVQVAE` from config.
+
+    Parameters
+    ----------
+    config : ModelConfig
+        Model hyper-parameters.
+    n_genes : int
+        Feature-space size (from the data source's :class:`GeneVocabulary`).
+
+    Returns
+    -------
+    OmicsVQVAE
+        The constructed model.
+
+    Raises
+    ------
+    ValueError
+        If ``config.n_genes`` is set and disagrees with ``n_genes``.
+    """
+    from omvqvae.models.vqvae import OmicsVQVAE
+
+    if config.n_genes is not None and config.n_genes != n_genes:
+        raise ValueError(
+            f"model.n_genes={config.n_genes} disagrees with the data source's "
+            f"gene-space size ({n_genes})."
+        )
+    return OmicsVQVAE(
+        n_genes,
+        n_latent=config.n_latent,
+        hidden_dims=tuple(config.hidden_dims),
+        likelihood=config.likelihood,
+        codebook_size=config.codebook_size,
+        n_codebooks=config.n_codebooks,
+        commitment_cost=config.commitment_cost,
+        ema=config.ema,
+        ema_decay=config.ema_decay,
+        reset_dead_codes=config.reset_dead_codes,
+        dropout=config.dropout,
+    )
+
+
+def build_train_config(config: TrainingConfig) -> TrainConfig:
+    """Map a :class:`TrainingConfig` onto the loop's :class:`TrainConfig`."""
+    return TrainConfig(
+        max_epochs=config.max_epochs,
+        lr=config.lr,
+        weight_decay=config.weight_decay,
+        grad_clip_norm=config.grad_clip_norm,
+        max_steps=config.max_steps,
+        log_every=config.log_every,
+        device=config.device,
+    )
+
+
+def build_tracker_from_config(
+    config: TrackingConfig,
+    *,
+    run_config: Optional[Dict[str, Any]] = None,
+) -> ExperimentTracker:
+    """Construct an :class:`ExperimentTracker` from a :class:`TrackingConfig`.
+
+    Parameters
+    ----------
+    config : TrackingConfig
+        Backend selection and run metadata.
+    run_config : Dict[str, Any], optional
+        Flattened run configuration logged to the tracker for reproducibility.
+
+    Returns
+    -------
+    ExperimentTracker
+        The constructed tracker (already given ``run_config`` to log).
+    """
+    return build_tracker(
+        config.backend,
+        run_name=config.run_name,
+        project=config.project,
+        config=run_config,
+        offline=config.offline,
+    )
+
+
+def build_data(config: DataConfig) -> Tuple[Iterable["Minibatch"], "GeneVocabulary"]:
+    """Build a data loader and its :class:`GeneVocabulary` from config.
+
+    For the local AnnData source the reference vocabulary is derived from the
+    file's own genes; for the Census source it is read from the Census ``var``
+    index. The returned loader yields :class:`Minibatch` batches in both cases.
+
+    Parameters
+    ----------
+    config : DataConfig
+        Data-source configuration.
+
+    Returns
+    -------
+    tuple of (Iterable[Minibatch], GeneVocabulary)
+        The minibatch loader and the reference vocabulary (its ``n_genes`` sizes
+        the model).
+
+    Raises
+    ------
+    ValueError
+        If ``config.source`` is unknown, or required fields are missing.
+    """
+    source = config.source.lower()
+    if source == "anndata":
+        return _build_anndata_data(config)
+    if source == "census":  # pragma: no cover - requires live Census/TileDB-SOMA
+        return _build_census_data(config)
+    raise ValueError(
+        f"Unknown data source {config.source!r}; expected 'anndata' or 'census'."
+    )
+
+
+def _build_anndata_data(
+    config: DataConfig,
+) -> Tuple[Iterable["Minibatch"], "GeneVocabulary"]:
+    """Build a local-AnnData loader + vocabulary (reference = the file's genes)."""
+    from omvqvae.data.anndata_io import (
+        build_anndata_dataloader,
+        extract_counts,
+        load_anndata,
+    )
+    from omvqvae.data.dataset import GeneVocabulary
+
+    if config.path is None:
+        raise ValueError("data.path is required when data.source == 'anndata'.")
+    adata = load_anndata(config.path)
+    _, gene_ids = extract_counts(adata, layer=config.layer, var_key=config.var_key)
+    vocabulary = GeneVocabulary(config.organism, gene_ids)
+    loader = build_anndata_dataloader(
+        adata,
+        vocabulary,
+        batch_size=config.batch_size,
+        shuffle=config.shuffle,
+        num_workers=config.num_workers,
+        layer=config.layer,
+        var_key=config.var_key,
+        batch_key=config.batch_key,
+        min_overlap=config.min_overlap,
+        size_factor_mode=config.size_factor_mode,
+    )
+    return loader, vocabulary
+
+
+def _build_census_data(  # pragma: no cover - requires live Census/TileDB-SOMA
+    config: DataConfig,
+) -> Tuple[Iterable["Minibatch"], "GeneVocabulary"]:
+    """Build a Census streaming loader + vocabulary (the networked source)."""
+    from omvqvae.data.census import (
+        DEFAULT_CENSUS_VERSION,
+        build_census_dataloader,
+        census_gene_vocabulary,
+        open_census,
+    )
+
+    census = open_census(census_version=config.census_version or DEFAULT_CENSUS_VERSION)
+    vocabulary = census_gene_vocabulary(
+        census,
+        config.organism,
+        var_value_filter=config.var_value_filter,
+    )
+    loader = build_census_dataloader(
+        census,
+        config.organism,
+        vocabulary,
+        obs_value_filter=config.obs_value_filter,
+        var_value_filter=config.var_value_filter,
+        batch_size=config.batch_size,
+        shuffle=config.shuffle,
+        num_workers=config.num_workers,
+        batch_key=config.batch_key,
+        size_factor_mode=config.size_factor_mode,
+        min_overlap=config.min_overlap,
+    )
+    return loader, vocabulary
+
+
+# --------------------------------------------------------------------------- #
+# Orchestration
+# --------------------------------------------------------------------------- #
+def _set_seed(seed: Optional[int]) -> None:
+    """Seed Python, NumPy, and Torch RNGs for reproducible runs."""
+    if seed is None:
+        return
+    import numpy as np
+    import torch
+
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+
+
+def run_experiment(
+    config: ExperimentConfig,
+    *,
+    tracker: Optional[ExperimentTracker] = None,
+    data: Optional[Tuple[Iterable["Minibatch"], "GeneVocabulary"]] = None,
+) -> Tuple["TrainResult", "OmicsVQVAE"]:
+    """Run a full training experiment from a resolved config.
+
+    Parameters
+    ----------
+    config : ExperimentConfig
+        The resolved configuration.
+    tracker : ExperimentTracker, optional
+        A pre-built tracker (injected in tests); when ``None`` one is built from
+        ``config.tracking`` and closed when training finishes.
+    data : tuple of (Iterable[Minibatch], GeneVocabulary), optional
+        A pre-built data source (injected in tests); when ``None`` it is built
+        from ``config.data``.
+
+    Returns
+    -------
+    tuple of (TrainResult, OmicsVQVAE)
+        The training outcome and the trained model.
+    """
+    _set_seed(config.seed)
+    loader, vocabulary = data if data is not None else build_data(config.data)
+    model = build_model(config.model, n_genes=vocabulary.n_genes)
+    train_config = build_train_config(config.training)
+
+    owns_tracker = tracker is None
+    if tracker is None:
+        run_config = cast(
+            Dict[str, Any],
+            OmegaConf.to_container(OmegaConf.structured(config), resolve=True),
+        )
+        tracker = build_tracker_from_config(config.tracking, run_config=run_config)
+    try:
+        result = run_train(model, loader, config=train_config, tracker=tracker)
+    finally:
+        if owns_tracker:
+            tracker.finish()
+
+    if config.training.checkpoint_path is not None:
+        _save_checkpoint(model, vocabulary, config, config.training.checkpoint_path)
+    return result, model
+
+
+def _save_checkpoint(
+    model: "OmicsVQVAE",
+    vocabulary: "GeneVocabulary",
+    config: ExperimentConfig,
+    path: str,
+) -> None:
+    """Persist the trained model weights, gene vocabulary, and config."""
+    import torch
+
+    out = Path(path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    torch.save(
+        {
+            "state_dict": model.state_dict(),
+            "organism": vocabulary.organism,
+            "gene_ids": vocabulary.gene_ids,
+            "config": OmegaConf.to_container(
+                OmegaConf.structured(config), resolve=True
+            ),
+        },
+        out,
+    )
+    logger.info("Saved checkpoint to %s", out)
+
+
+# --------------------------------------------------------------------------- #
+# Typer CLI
+# --------------------------------------------------------------------------- #
+def _build_app() -> Any:
+    """Construct the Typer application (lazy import keeps ``typer`` optional)."""
+    import typer
+
+    app = typer.Typer(
+        add_completion=False,
+        help="Train or fine-tune an OQAE (Omics Quantized Auto Encoder) model.",
+    )
+
+    @app.command("train")
+    def train_command(
+        config: Optional[Path] = typer.Argument(
+            None,
+            help="Path to a YAML config file (defaults are used when omitted).",
+        ),
+        set_: Optional[List[str]] = typer.Option(
+            None,
+            "--set",
+            "-s",
+            help="OmegaConf dot-list override, e.g. -s training.lr=1e-2 "
+            "(repeatable).",
+        ),
+    ) -> None:
+        """Train a model from a config file (plus optional ``--set`` overrides)."""
+        cfg = load_config(config, overrides=set_)
+        result, _ = run_experiment(cfg)
+        last = result.last_epoch
+        if last is not None:
+            typer.echo(
+                f"Done: {result.global_step} steps, "
+                f"final loss={last.loss:.4g} (recon={last.reconstruction_loss:.4g}, "
+                f"vq={last.vq_loss:.4g}, ppl={last.perplexity:.4g})."
+            )
+        else:  # pragma: no cover - defensive; the loop always records an epoch
+            typer.echo("Done: no steps were taken (empty data source).")
+
+    return app
+
+
+#: The Typer application (built at import time).
+app = _build_app()
+
+
+def main() -> None:  # pragma: no cover - thin console-script entry point
+    """Console-script entry point (``oqae-train``)."""
+    app()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/train/test_cli.py
+++ b/tests/train/test_cli.py
@@ -1,0 +1,293 @@
+"""Offline tests for the config-driven training CLI.
+
+These exercise the config schema/loading, each ``config -> object`` builder, the
+full ``run_experiment`` wiring against a synthetic local ``.h5ad``, and the Typer
+command via ``CliRunner`` — all without network access or a real ``wandb`` run.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+import pytest
+import torch
+from anndata import AnnData
+from typer.testing import CliRunner
+
+from omvqvae.models.vqvae import OmicsVQVAE
+from omvqvae.train.cli import (
+    DataConfig,
+    ExperimentConfig,
+    ModelConfig,
+    TrackingConfig,
+    TrainingConfig,
+    app,
+    build_data,
+    build_model,
+    build_tracker_from_config,
+    build_train_config,
+    load_config,
+    run_experiment,
+)
+from omvqvae.utils.tracking import ConsoleTracker, ExperimentTracker
+
+GENE_IDS = ["ENSG1", "ENSG2", "ENSG3", "ENSG4", "ENSG5"]
+
+
+class _RecordingTracker(ExperimentTracker):
+    """A tracker that records everything passed to it (no I/O)."""
+
+    def __init__(self) -> None:
+        self.configs: List[Dict[str, Any]] = []
+        self.logs: List[Tuple[Dict[str, float], Optional[int]]] = []
+        self.finished = False
+
+    def log_config(self, config: Mapping[str, Any]) -> None:
+        self.configs.append(dict(config))
+
+    def log(self, metrics: Mapping[str, float], *, step: Optional[int] = None) -> None:
+        self.logs.append((dict(metrics), step))
+
+    def finish(self) -> None:
+        self.finished = True
+
+
+def _make_h5ad(path: Path, *, n_cells: int = 24, seed: int = 0) -> None:
+    """Write a tiny synthetic raw-count ``.h5ad`` to ``path``."""
+    rng = np.random.default_rng(seed)
+    counts = rng.poisson(lam=3.0, size=(n_cells, len(GENE_IDS))).astype(np.float32)
+    obs = pd.DataFrame(index=[f"cell_{i}" for i in range(n_cells)])
+    obs["batch"] = [f"b{i % 2}" for i in range(n_cells)]
+    var = pd.DataFrame(index=list(GENE_IDS))
+    AnnData(X=counts, obs=obs, var=var).write_h5ad(path)
+
+
+# --------------------------------------------------------------------------- #
+# Config loading
+# --------------------------------------------------------------------------- #
+def test_load_config_defaults() -> None:
+    cfg = load_config()
+    assert isinstance(cfg, ExperimentConfig)
+    assert isinstance(cfg.model, ModelConfig)
+    assert cfg.model.likelihood == "nb"
+    assert cfg.data.source == "anndata"
+    assert cfg.training.max_epochs == 1
+    assert cfg.tracking.backend == "console"
+
+
+def test_load_config_yaml_and_overrides(tmp_path: Path) -> None:
+    yaml = tmp_path / "cfg.yaml"
+    yaml.write_text(
+        "model:\n  n_latent: 4\n  hidden_dims: [8]\n" "training:\n  max_epochs: 3\n"
+    )
+    cfg = load_config(yaml, overrides=["training.lr=0.05", "data.path=foo.h5ad"])
+    assert cfg.model.n_latent == 4
+    assert cfg.model.hidden_dims == [8]
+    assert cfg.training.max_epochs == 3
+    assert cfg.training.lr == pytest.approx(0.05)
+    assert cfg.data.path == "foo.h5ad"
+
+
+def test_load_config_missing_file(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        load_config(tmp_path / "nope.yaml")
+
+
+def test_load_config_rejects_unknown_key(tmp_path: Path) -> None:
+    yaml = tmp_path / "cfg.yaml"
+    yaml.write_text("model:\n  not_a_field: 1\n")
+    with pytest.raises(Exception):
+        load_config(yaml)
+
+
+# --------------------------------------------------------------------------- #
+# Builders
+# --------------------------------------------------------------------------- #
+def test_build_model() -> None:
+    model = build_model(
+        ModelConfig(n_latent=8, hidden_dims=[16], n_codebooks=3, codebook_size=32),
+        n_genes=7,
+    )
+    assert isinstance(model, OmicsVQVAE)
+    assert model.n_genes == 7
+    assert model.n_latent == 8
+    assert model.n_codebooks == 3
+
+
+def test_build_model_n_genes_mismatch_raises() -> None:
+    with pytest.raises(ValueError, match="disagrees"):
+        build_model(ModelConfig(n_genes=10), n_genes=7)
+
+
+def test_build_train_config_maps_fields() -> None:
+    tc = build_train_config(
+        TrainingConfig(max_epochs=4, lr=0.01, grad_clip_norm=2.0, max_steps=9)
+    )
+    assert tc.max_epochs == 4
+    assert tc.lr == pytest.approx(0.01)
+    assert tc.grad_clip_norm == pytest.approx(2.0)
+    assert tc.max_steps == 9
+
+
+def test_build_tracker_console() -> None:
+    tracker = build_tracker_from_config(
+        TrackingConfig(backend="console", run_name="r"), run_config={"a": 1}
+    )
+    assert isinstance(tracker, ConsoleTracker)
+
+
+def test_build_data_anndata(tmp_path: Path) -> None:
+    path = tmp_path / "cells.h5ad"
+    _make_h5ad(path)
+    loader, vocab = build_data(DataConfig(source="anndata", path=str(path)))
+    assert vocab.n_genes == len(GENE_IDS)
+    assert vocab.organism == "homo_sapiens"
+    batch = next(iter(loader))
+    assert batch.counts.shape[1] == len(GENE_IDS)
+
+
+def test_build_data_anndata_requires_path() -> None:
+    with pytest.raises(ValueError, match="data.path is required"):
+        build_data(DataConfig(source="anndata", path=None))
+
+
+def test_build_data_unknown_source() -> None:
+    with pytest.raises(ValueError, match="Unknown data source"):
+        build_data(DataConfig(source="bogus"))
+
+
+# --------------------------------------------------------------------------- #
+# Orchestration
+# --------------------------------------------------------------------------- #
+def _toy_config(path: Path) -> ExperimentConfig:
+    return ExperimentConfig(
+        seed=0,
+        model=ModelConfig(
+            n_latent=8, hidden_dims=[16], codebook_size=16, n_codebooks=2
+        ),
+        data=DataConfig(source="anndata", path=str(path), batch_size=8, shuffle=False),
+        training=TrainingConfig(max_epochs=3, lr=0.01, log_every=1),
+        tracking=TrackingConfig(backend="console"),
+    )
+
+
+def test_run_experiment_trains_and_logs(tmp_path: Path) -> None:
+    path = tmp_path / "cells.h5ad"
+    _make_h5ad(path)
+    cfg = _toy_config(path)
+    tracker = _RecordingTracker()
+
+    result, model = run_experiment(cfg, tracker=tracker)
+
+    assert isinstance(model, OmicsVQVAE)
+    assert result.global_step > 0
+    assert len(result.epochs) == 3
+    # Injected tracker lifecycle is owned by the caller, so it is not finished.
+    assert tracker.finished is False
+    assert tracker.logs, "expected per-step metrics to be logged"
+    # Reconstruction loss should not increase from the first to the last epoch.
+    assert result.epochs[-1].reconstruction_loss <= result.epochs[0].reconstruction_loss
+
+
+def test_run_experiment_writes_checkpoint(tmp_path: Path) -> None:
+    path = tmp_path / "cells.h5ad"
+    _make_h5ad(path)
+    ckpt = tmp_path / "out" / "model.pt"
+    cfg = _toy_config(path)
+    cfg.training.checkpoint_path = str(ckpt)
+
+    run_experiment(cfg, tracker=_RecordingTracker())
+
+    assert ckpt.exists()
+    payload = torch.load(ckpt, weights_only=False)
+    assert payload["organism"] == "homo_sapiens"
+    assert payload["gene_ids"] == GENE_IDS
+    assert "state_dict" in payload
+
+
+def test_run_experiment_builds_default_tracker(tmp_path: Path) -> None:
+    path = tmp_path / "cells.h5ad"
+    _make_h5ad(path)
+    cfg = _toy_config(path)
+    cfg.training.max_steps = 2
+    # No tracker injected: run_experiment builds and finishes its own.
+    result, _ = run_experiment(cfg)
+    assert result.global_step > 0
+
+
+def test_run_experiment_seed_none_runs(tmp_path: Path) -> None:
+    path = tmp_path / "cells.h5ad"
+    _make_h5ad(path)
+    cfg = _toy_config(path)
+    cfg.seed = None
+    cfg.training.max_steps = 2
+    result, _ = run_experiment(cfg, tracker=_RecordingTracker())
+    assert result.global_step > 0
+
+
+def test_run_experiment_seed_is_deterministic(tmp_path: Path) -> None:
+    path = tmp_path / "cells.h5ad"
+    _make_h5ad(path)
+    cfg = _toy_config(path)
+    cfg.training.max_steps = 3
+
+    _, model_a = run_experiment(cfg, tracker=_RecordingTracker())
+    _, model_b = run_experiment(cfg, tracker=_RecordingTracker())
+
+    for pa, pb in zip(model_a.parameters(), model_b.parameters()):
+        assert torch.allclose(pa, pb)
+
+
+# --------------------------------------------------------------------------- #
+# Typer CLI
+# --------------------------------------------------------------------------- #
+def test_cli_train_end_to_end(tmp_path: Path) -> None:
+    path = tmp_path / "cells.h5ad"
+    _make_h5ad(path)
+    yaml = tmp_path / "cfg.yaml"
+    yaml.write_text(
+        "model:\n  n_latent: 8\n  hidden_dims: [16]\n  codebook_size: 16\n"
+        f"data:\n  source: anndata\n  path: {path}\n  batch_size: 8\n"
+        "training:\n  max_epochs: 2\n  log_every: 1\n"
+        "tracking:\n  backend: none\n"
+    )
+    runner = CliRunner()
+    result = runner.invoke(app, [str(yaml)])
+    assert result.exit_code == 0, result.output
+    assert "Done:" in result.output
+    assert "final loss" in result.output
+
+
+def test_cli_train_with_overrides_and_checkpoint(tmp_path: Path) -> None:
+    path = tmp_path / "cells.h5ad"
+    _make_h5ad(path)
+    ckpt = tmp_path / "model.pt"
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "--set",
+            "data.source=anndata",
+            "--set",
+            f"data.path={path}",
+            "--set",
+            "data.batch_size=8",
+            "--set",
+            "model.n_latent=8",
+            "--set",
+            "model.hidden_dims=[16]",
+            "--set",
+            "model.codebook_size=16",
+            "--set",
+            "training.max_steps=2",
+            "--set",
+            "tracking.backend=none",
+            "--set",
+            f"training.checkpoint_path={ckpt}",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert ckpt.exists()


### PR DESCRIPTION
## Summary

Completes **PR #5** by wiring a config-driven entry point on top of the slice-1 training loop (`omvqvae.train.train`) and experiment tracker.

Adds `src/omvqvae/train/cli.py`:

- **OmegaConf structured config** — `ExperimentConfig` plus per-section dataclasses (`ModelConfig`, `DataConfig`, `TrainingConfig`, `TrackingConfig`). Loading merges typed defaults ← user YAML ← `--set a.b=c` dot-list overrides, validates types, and **rejects unknown keys**.
- **Pure builders** mapping one config section → one object: `build_model`, `build_train_config`, `build_tracker_from_config`, `build_data`. `run_experiment` wires them and calls `omvqvae.train.train`.
- **Data sources**: the local `.h5ad` / `.zarr` path derives its `GeneVocabulary` (and the model's `n_genes`) from the file's own genes; the **Census** streaming path is the single networked branch (gated, `# pragma: no cover`).
- **Checkpointing**: optional `training.checkpoint_path` persists `{state_dict, organism, gene_ids, config}` — the seed for PR #6 (HF Hub) / PR #7 (inference) to reload a model on the right feature space.
- **CLI**: a single-command `typer` app exposed as the `oqae-train` console script (`[project.scripts]`), so `oqae-train config.yaml -s training.lr=1e-2` just works.
- Ships `configs/train_toy.yaml`.

## Design notes

Follows the project's "pure core + thin I/O shell" convention — the config→objects wiring is fully offline-testable; only the Census loader and the real `wandb.init` (already isolated in `utils/tracking`) touch the network. Per the codebase idiom, heavy deps (`torch`, `anndata`, `typer`) are lazy-imported inside the functions that use them.

## Tests

`tests/train/test_cli.py` — offline coverage of:
- config loading: defaults, YAML + overrides, missing-file, unknown-key rejection;
- every builder (incl. `n_genes` mismatch guard, unknown-source guard);
- `run_experiment` against a synthetic `.h5ad` (loss non-increasing, checkpoint payload, default-tracker lifecycle, seed determinism);
- the `oqae-train` command end-to-end via Typer's `CliRunner` (config file + `--set` overrides + checkpoint).

`make ci` green (black/isort/flake8/mypy-strict/pytest); ~99% coverage. No new dependencies — all CLI deps were already declared, so `uv.lock` is unchanged.

## Docs

`docs/STATUS.md` and `docs/PROJECT_PLAN.md` updated: PR #5 marked complete, new **Next task = PR #6 (HuggingFace Hub integration)**, decisions-log entry for the CLI/config design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013uN9JyAGLFurSNaVBMysBF)_