### PR TITLE
feat(inference): discrete-code inference API (PR #7)

### DIFF
--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -309,13 +309,23 @@ src/omvqvae/
 
 ### **Phase 3: Latent API, Examples & Release (PRs 7–10)**
 
-#### **PR #7: Discrete-Code Inference API**
+#### **PR #7: Discrete-Code Inference API — ✅ DONE**
 - **Scope**: `encode(adata) → discrete codes` and
   `decode(codes) → expression`; the universal-latent use cases (compression,
   generation, plugging codes into the decoder).
-- **Files**: `inference/codes.py`.
-- **Exit criteria**: round-trip encode→decode on held-out cells; documented
-  code-vector format.
+- **Files**: `inference/codes.py` (+ `inference/__init__.py`).
+- **Status**: complete. `encode` / `encode_anndata` produce an `EncodedCells`
+  bundle (`codes` `(n_cells, n_codebooks)` int64 + per-cell `size_factors` +
+  continuous `latent`); `encode_anndata` aligns a local AnnData to the model's
+  `GeneVocabulary` first. `decode` maps codes → expected counts and
+  `decode_to_params` exposes the full head distribution. The inverse path is a
+  tested model/layer method (`VectorQuantizer.lookup` / `ResidualVQ.lookup`,
+  `OmicsVQVAE.decode_codes` / `codes_to_params`), not internal poking. Inference
+  runs in `eval` + `no_grad` (EMA codebooks untouched) and restores the model's
+  prior mode; `encode`/`decode` are batched. No new deps.
+- **Exit criteria** (met): round-trip encode→decode on held-out synthetic cells;
+  documented code-vector format (see `inference/codes.py` module docstring); 100%
+  offline coverage on the module; `make ci` green.
 
 #### **PR #8: Examples & Documentation**
 - **Scope**: notebooks (Census streaming, local fine-tuning, code
@@ -414,6 +424,7 @@ A running record of decisions so future sessions don't re-litigate them.
 | 2026-06-21 | **Split PR #4 into slices; do the likelihood heads first, independently of the residual VQ.** PR #3 (residual VQ) was concurrently in flight as PR #24, so this run built `models/likelihoods.py` (no VQ dependency) rather than duplicating or blocking on it; once PR #24 merged, `main` was merged back in. The VQ-VAE core (`models/vqvae.py`) is slice 2 and composes `ResidualVQ` + a `ReconstructionHead`. | Avoids duplicating in-flight work and a docs merge conflict; keeps each run to one coherent, CI-verifiable chunk. |
 | 2026-06-22 | **`OmicsVQVAE` = symmetric MLP encoder/decoder around `ResidualVQ` + a `ReconstructionHead`.** Encoder input is internally `log1p`-transformed for numerical stability; the reconstruction *target* is raw counts for NB/ZINB and `log1p` expression for the Gaussian head. Decoder hidden widths mirror the encoder (`hidden_dims` reversed); the head consumes the final decoder hidden dim. `forward` returns a `VQVAEOutput` composing recon + VQ loss with the per-level codes and codebook metrics. Total loss = `reconstruction_loss + vq.loss` (per-cell-mean recon NLL + mean VQ loss), unweighted in v1. | Keeps depth/normalization handling inside the model and count statistics intact; one symmetric, configurable module covers all three likelihoods. The `VQVAEOutput` bundle hands PR #5 its loss + W&B monitoring signals without coupling to the layer internals. Loss-term weighting is left as a future tuning knob. |
 | 2026-06-25 | **HF serialization = self-describing model + a HuggingFace-style directory.** Added `OmicsVQVAE.get_config()` / `from_config()` (the model carries every constructor hyper-parameter), so `hf_utils.save_pretrained` writes `config.json` (`{format_version, organism, gene_ids, model=get_config(), experiment_config}`) + `pytorch_model.bin` and `load_pretrained` rebuilds the exact model/feature space — decoupled from the training CLI. `hf_utils.py` lives at the **package top level** (per the package-structure diagram, not under `models/` or `inference/`). `from_checkpoint` converts a CLI `{state_dict, organism, gene_ids, config}` bundle into the same directory shape so both share one format; `push_to_hub` / `from_pretrained` are thin `huggingface_hub` shells (`# pragma: no cover`, network-gated) wrapping the tested pure save/load step. Added direct dep `huggingface-hub>=0.20.0` (already transitive via `transformers`). | Making the model self-describing is the standard HF `PreTrainedModel` pattern and keeps serialization independent of `train.cli`/OmegaConf. A plain JSON+weights directory *is* a Hub-ready repo and is fully offline-testable, leaving only upload/download as the networked edge. Reusing the CLI bundle's architecture fields via `from_checkpoint` avoids two divergent on-disk formats. |
+| 2026-06-26 | **Discrete-code inference API = free functions over a trained model returning an `EncodedCells` bundle, with the code→vector inverse path pushed into the layer/model.** `inference/codes.py` exposes `encode`/`encode_anndata` (→ `EncodedCells{codes (n_cells, n_codebooks) int64, size_factors, latent}`) and `decode`/`decode_to_params`. The codes alone don't reconstruct depth — decoding needs a per-cell `size_factor`, so `encode` returns it in the bundle and `decode` reuses it (overridable). The inverse `indices → summed quantized vector` is a tested `ResidualVQ.lookup` / `OmicsVQVAE.decode_codes` method rather than reaching into codebook buffers. All inference forces `eval` + `no_grad` (so EMA/dead-code stats aren't mutated) and restores the prior mode; `encode`/`decode` are batched. `encode_anndata` takes a `LoadedModel` and aligns via `align_to_reference` (annotation under `TYPE_CHECKING` to avoid an import cycle / heavy import). | Free functions keep the API thin and match the functional style of the data/train layers; the `EncodedCells` bundle makes the codes+size-factor pair (the actual compressed representation) explicit and gives a frictionless `decode(model, encode(model, x))` round-trip. Putting `lookup`/`decode_codes` on the layer/model keeps inference decoupled from quantizer internals and is reusable by generation/benchmarking PRs. Forcing eval/no_grad prevents inference from silently drifting the codebooks. |
 | 2026-06-24 | **Training CLI = OmegaConf structured config + a single-command typer app (`oqae-train`).** The config schema is plain dataclasses (`ExperimentConfig`/`ModelConfig`/`DataConfig`/`TrainingConfig`/`TrackingConfig`) so OmegaConf validates the YAML, rejects unknown keys, and supports `--set a.b=c` dot-list overrides; `OmegaConf.to_object` yields typed objects for mypy. Pure builders (`build_model`/`build_train_config`/`build_tracker_from_config`/`build_data`) map one config section → one object and `run_experiment` wires them, so the config→objects path is unit-tested offline. The **local-AnnData** source derives its `GeneVocabulary` (hence the model's `n_genes`) from the file's own genes; the **Census** source is the one networked branch (`# pragma: no cover`). The optional checkpoint stores `{state_dict, organism, gene_ids, config}`. | A declarative, schema-checked config keeps runs reproducible and overridable from the shell; the pure-builder split keeps the heavy/networked I/O at the edges and everything else offline-testable (incl. via Typer's `CliRunner`). Persisting `gene_ids`/`organism`/`config` alongside the weights is what PR #6 (HF Hub) and PR #7 (inference) need to reload a model against the right feature space. Single-command typer means `oqae-train config.yaml` with no redundant subcommand name. |
 
 ## 🔄 **Future Roadmap (Post-v1.0)**
@@ -431,10 +442,12 @@ A running record of decisions so future sessions don't re-litigate them.
 
 ---
 
-**Last Updated**: 2026-06-25 — PR #6 complete: `hf_utils.py` round-trips a
-trained `OmicsVQVAE` (state dict + codebooks + config + gene vocabulary) through
-a HuggingFace-style directory; the model is self-describing via
-`get_config()`/`from_config()`.
-**Current Focus**: PR #7 — discrete-code inference API (`inference/codes.py`:
-`encode → codes`, `decode → expression`; see `docs/STATUS.md`).
-**Next Review**: After PR #7 (discrete-code inference API).
+**Last Updated**: 2026-06-26 — PR #7 complete: `omvqvae.inference`
+(`inference/codes.py`) is the discrete-code latent API — `encode`/`encode_anndata`
+→ `EncodedCells` (codes + size factors + latent), `decode`/`decode_to_params` →
+expression, with the code→vector inverse path (`ResidualVQ.lookup` /
+`OmicsVQVAE.decode_codes`) on the layer/model.
+**Current Focus**: PR #8 — examples & documentation (notebooks for Census
+streaming / local fine-tuning / code inspection + generation; Sphinx docs; see
+`docs/STATUS.md`).
+**Next Review**: After PR #8 (examples & documentation).

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -4,7 +4,7 @@
 > end of every working session** so the next session can pick up cold. Keep it
 > short; deep rationale lives in `docs/PROJECT_PLAN.md`.
 
-**Last updated:** 2026-06-25
+**Last updated:** 2026-06-26
 
 ## Current state
 
@@ -124,35 +124,62 @@
     eval-mode, every validation/error path, and the `from_checkpoint` bridge)
     plus `get_config`/`from_config` tests on the model; `make ci` green (~99.7%).
 
-## Next task — PR #7: Discrete-code inference API
+- **PR #7 (discrete-code inference API) — DONE (this PR). PR #7 complete.**
+  - `inference/codes.py` — the user-facing latent interface on top of a trained
+    `OmicsVQVAE`. `encode(model, counts, ...) → EncodedCells` turns raw counts
+    (tensor / ndarray / sparse) into discrete codes; `encode_anndata(loaded,
+    adata, ...)` aligns a local AnnData to the model's `GeneVocabulary`
+    (`align_to_reference`) first. `decode(model, codes_or_bundle, size_factors)`
+    maps codes back to **expected counts**; `decode_to_params` exposes the full
+    head distribution (for sampling/generation). All run the model in `eval` +
+    `no_grad` (EMA codebooks untouched) and restore its prior train/eval mode;
+    `encode`/`decode` are batched.
+  - **Code-vector format**: `EncodedCells.codes` is an `int64`
+    `(n_cells, n_codebooks)` tensor — row = a cell's discrete code, column `j` =
+    the index chosen from residual codebook `j` (in `[0, codebook_size)`).
+    Decoding also needs a per-cell `size_factor` (observed depth), which `encode`
+    returns alongside the codes; `decode` reuses the bundle's factors unless
+    overridden. `EncodedCells` also carries the continuous pre-quantization
+    `latent` for quantization-error inspection.
+  - **Inverse path added to the layer/model**: `VectorQuantizer.lookup` /
+    `ResidualVQ.lookup` (indices → summed quantized vector) and
+    `OmicsVQVAE.decode_codes` / `codes_to_params` (codes → expected counts /
+    head params), so codes → quantized vectors → `expected_counts` is a tested
+    model method rather than reaching into internals.
+  - No new deps; `uv.lock` unchanged. Offline tests at 100% coverage on
+    `inference/codes.py` (round-trip on held-out synthetic cells, batched ==
+    unbatched, numpy/sparse inputs, AnnData alignment incl. reordered/missing/
+    extra genes, size-factor scaling, eval-mode side-effect freedom, every
+    validation/error path) plus `lookup`/`decode_codes` tests; `make ci` green
+    (~99.7%).
 
-PR #6 is **DONE**. Next is the user-facing latent API on top of the trained
-model + HF loading:
+## Next task — PR #8: Examples & documentation
 
-1. `inference/codes.py` — `encode(adata) → discrete codes` and
-   `decode(codes) → expression` for the universal-latent use cases (compression,
-   generation, plugging codes back into the decoder). Operate on local AnnData
-   (align to the model's `GeneVocabulary` via `align_to_reference`) and/or raw
-   count tensors; return codes as `(n_cells, n_codebooks)` indices and an
-   inverse path that maps codes → quantized vectors → `expected_counts`.
-2. Reuse the loaded model from `omvqvae.hf_utils.load_pretrained` /
-   `from_pretrained` so inference runs on the right feature space. Document the
-   code-vector format. Keep it offline-testable on synthetic data.
+PR #7 is **DONE**. Next is PR #8 (Phase 3):
 
-**Definition of done:** round-trip encode→decode on held-out synthetic cells;
-documented code-vector format; CI green; PR opened.
+1. Example notebooks under `examples/` (or `docs/`): Census streaming training,
+   local `.h5ad` fine-tuning, and **code inspection / generation** using the new
+   `omvqvae.inference` API (`encode` → inspect codes → `decode` /
+   `decode_to_params`). Keep them runnable on tiny synthetic data so they don't
+   require network/Census.
+2. Sphinx docs scaffold (autodoc the public API: `data`, `layers`, `models`,
+   `train`, `inference`, `hf_utils`). Make `docs/` build.
 
-### Available building blocks
+**Definition of done:** docs build; examples run on small data; CI green; PR
+opened. Consider splitting into a slice (notebooks first, Sphinx second) if it
+grows beyond one PR-sized chunk.
 
+### Available building blocks (for PR #8)
+
+- `omvqvae.inference`: `encode` / `encode_anndata` / `decode` /
+  `decode_to_params` / `EncodedCells` — the latent API the examples demonstrate.
 - `omvqvae.hf_utils`: `save_pretrained` / `load_pretrained` / `from_checkpoint` /
-  `push_to_hub` / `from_pretrained`, returning a `LoadedModel`
-  (`model`/`vocabulary`/`experiment_config`). The model is self-describing via
-  `OmicsVQVAE.get_config()` / `OmicsVQVAE.from_config()`.
-- `omvqvae.models.vqvae.OmicsVQVAE`: `encode` / `quantize` / `encode_codes` /
-  `decode` / `expected_counts` already expose the code↔expression mapping the
-  inference API wraps.
-- `omvqvae.data`: `GeneVocabulary` / `align_to_reference` / `Minibatch` /
-  `load_anndata` / `extract_counts` for aligning input to the model's genes.
+  `push_to_hub` / `from_pretrained` → `LoadedModel`
+  (`model`/`vocabulary`/`experiment_config`).
+- `omvqvae.train`: `train` + `oqae-train` CLI (`run_experiment`, builders) and
+  `configs/train_toy.yaml` for the training examples.
+- `omvqvae.data`: `GeneVocabulary` / `align_to_reference` / `build_anndata_dataloader`
+  / `build_census_dataloader` for the data-loading examples.
 
 ## Open questions / parked
 
@@ -171,6 +198,22 @@ documented code-vector format; CI green; PR opened.
 
 ## Changelog (most recent first)
 
+- **2026-06-26** — PR #7: discrete-code inference API. Added the
+  `omvqvae.inference` package (`inference/codes.py`): `encode` /
+  `encode_anndata` turn raw counts / a local AnnData (aligned to the model's
+  `GeneVocabulary`) into an `EncodedCells` bundle (`codes`
+  `(n_cells, n_codebooks)` int64 + per-cell `size_factors` + continuous
+  `latent`); `decode` maps codes → expected counts and `decode_to_params`
+  exposes the full head distribution. Inference runs in `eval` + `no_grad`
+  (EMA codebooks untouched) with the model's prior mode restored, and is
+  batched. Added the inverse path to the layer/model: `VectorQuantizer.lookup`
+  / `ResidualVQ.lookup` (indices → summed quantized vector) and
+  `OmicsVQVAE.decode_codes` / `codes_to_params`. No new deps; `uv.lock`
+  unchanged. Offline tests at 100% coverage on `inference/codes.py`
+  (held-out round-trip, batched == unbatched, numpy/sparse, AnnData alignment
+  with reordered/missing/extra genes, size-factor scaling, eval-mode
+  side-effect freedom, all error paths); `make ci` green (~99.7%). **PR #7 is
+  now complete.**
 - **2026-06-25** — PR #6: HuggingFace Hub integration. Added top-level
   `hf_utils.py` — `save_pretrained` / `load_pretrained` round-trip a trained
   `OmicsVQVAE` (state dict + codebooks), its architecture config, and the gene

--- a/src/omvqvae/inference/__init__.py
+++ b/src/omvqvae/inference/__init__.py
@@ -1,0 +1,24 @@
+"""
+Inference API for OQAE.
+
+The user-facing latent interface on top of a trained
+:class:`~omvqvae.models.vqvae.OmicsVQVAE`: encode expression into the model's
+discrete universal codes and decode codes back into expression (see
+:mod:`omvqvae.inference.codes`).
+"""
+
+from omvqvae.inference.codes import (
+    EncodedCells,
+    decode,
+    decode_to_params,
+    encode,
+    encode_anndata,
+)
+
+__all__ = [
+    "EncodedCells",
+    "encode",
+    "encode_anndata",
+    "decode",
+    "decode_to_params",
+]

--- a/src/omvqvae/inference/codes.py
+++ b/src/omvqvae/inference/codes.py
@@ -1,0 +1,381 @@
+"""
+Discrete-code inference API for OQAE.
+
+This is the user-facing latent interface on top of a trained
+:class:`~omvqvae.models.vqvae.OmicsVQVAE`: it turns expression into the model's
+**discrete universal codes** and turns codes back into expression.
+
+```
+counts ──encode──► codes (n_cells, n_codebooks)  ──decode──► expected counts
+                   + per-cell size factor
+```
+
+The two halves enable the universal-latent use cases:
+
+- **Compression / representation** — each cell becomes a tiny integer code
+  ``(n_codebooks,)`` (one codebook index per residual level) plus a scalar size
+  factor; that pair is everything needed to reconstruct it.
+- **Generation / decoding** — feed any codes (encoded or hand-constructed) back
+  through the generative decoder to produce expression profiles.
+
+Code-vector format
+------------------
+``encode`` returns an :class:`EncodedCells` bundle whose ``codes`` field is an
+``int64`` tensor of shape ``(n_cells, n_codebooks)``. Row ``i`` is cell ``i``'s
+discrete code; column ``j`` is the index it selected from residual codebook ``j``
+(each in ``[0, codebook_size)``). Decoding additionally needs a per-cell
+``size_factor`` (observed sequencing depth) so the decoder reconstructs
+depth-appropriate counts; ``encode`` returns these alongside the codes.
+
+Everything here runs the model in ``eval`` mode under ``torch.no_grad`` so the
+EMA codebooks / dead-code statistics are **not** mutated during inference; the
+model's previous train/eval mode is restored on exit.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Dict, Iterator, Optional, Union
+
+import numpy as np
+import torch
+from torch import Tensor
+
+from omvqvae.data.anndata_io import extract_counts
+from omvqvae.data.dataset import align_to_reference
+from omvqvae.data.normalize import CountMatrix, compute_size_factors, to_dense
+from omvqvae.utils.logging import get_logger
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from anndata import AnnData
+
+    from omvqvae.hf_utils import LoadedModel
+    from omvqvae.models.vqvae import OmicsVQVAE
+
+logger = get_logger(__name__)
+
+#: An array-like accepted as raw counts (dense, sparse, or a torch tensor).
+CountsLike = Union[Tensor, np.ndarray, "CountMatrix"]
+#: An array-like accepted as per-cell size factors.
+SizeFactorsLike = Union[Tensor, np.ndarray]
+#: An array-like accepted as discrete codes (or an :class:`EncodedCells` bundle).
+CodesLike = Union[Tensor, np.ndarray, "EncodedCells"]
+
+__all__ = [
+    "EncodedCells",
+    "encode",
+    "encode_anndata",
+    "decode",
+    "decode_to_params",
+]
+
+
+@dataclass
+class EncodedCells:
+    """
+    The discrete encoding of a batch of cells.
+
+    Attributes
+    ----------
+    codes : torch.Tensor
+        Per-cell discrete codes of shape ``(n_cells, n_codebooks)`` (``int64``);
+        column ``j`` is the index selected from residual codebook ``j``. This is
+        the compact universal representation.
+    size_factors : torch.Tensor
+        Per-cell size factors of shape ``(n_cells,)`` (``float32``) — the
+        observed sequencing depth needed to decode depth-appropriate counts.
+    latent : torch.Tensor
+        The continuous pre-quantization latent of shape ``(n_cells, n_latent)``
+        (``float32``); useful for inspecting quantization error but not required
+        for decoding.
+    """
+
+    codes: Tensor
+    size_factors: Tensor
+    latent: Tensor
+
+    def __len__(self) -> int:
+        return int(self.codes.shape[0])
+
+
+@contextmanager
+def _inference_mode(model: "OmicsVQVAE") -> Iterator[None]:
+    """Run ``model`` in ``eval`` + ``no_grad``, restoring its prior mode."""
+    was_training = model.training
+    model.eval()
+    try:
+        with torch.no_grad():
+            yield
+    finally:
+        if was_training:
+            model.train()
+
+
+def _counts_to_array(counts: CountsLike) -> np.ndarray:
+    """Coerce dense/sparse/tensor counts to a 2-D dense ``float32`` array."""
+    if isinstance(counts, Tensor):
+        dense = counts.detach().cpu().to(torch.float32).numpy()
+    else:
+        dense = to_dense(counts)
+    if dense.ndim != 2:
+        raise ValueError(f"counts must be 2-D (n_cells, n_genes); got {dense.ndim}-D.")
+    return dense
+
+
+def _resolve_size_factors(
+    dense: np.ndarray,
+    size_factors: Optional[SizeFactorsLike],
+    size_factor_mode: str,
+) -> Tensor:
+    """Return per-cell size factors as a ``float32`` tensor (computed if absent)."""
+    if size_factors is None:
+        factors = compute_size_factors(dense, mode=size_factor_mode)
+    else:
+        if isinstance(size_factors, Tensor):
+            factors = size_factors.detach().cpu().to(torch.float32).numpy()
+        else:
+            factors = np.asarray(size_factors, dtype=np.float32)
+        factors = factors.ravel()
+        if factors.shape[0] != dense.shape[0]:
+            raise ValueError(
+                f"size_factors has length {factors.shape[0]} but there are "
+                f"{dense.shape[0]} cells."
+            )
+    return torch.from_numpy(np.ascontiguousarray(factors, dtype=np.float32))
+
+
+def encode(
+    model: "OmicsVQVAE",
+    counts: CountsLike,
+    *,
+    size_factors: Optional[SizeFactorsLike] = None,
+    size_factor_mode: str = "total",
+    batch_size: int = 1024,
+) -> EncodedCells:
+    """
+    Encode raw counts to their discrete codes.
+
+    Parameters
+    ----------
+    model : OmicsVQVAE
+        A trained model; its ``n_genes`` must match the columns of ``counts``
+        (align local data with :func:`encode_anndata` first if it does not).
+    counts : torch.Tensor, numpy.ndarray, or scipy.sparse.spmatrix
+        Raw counts of shape ``(n_cells, n_genes)``.
+    size_factors : torch.Tensor or numpy.ndarray, optional
+        Per-cell size factors of shape ``(n_cells,)``. Computed from the counts
+        (via ``size_factor_mode``) when omitted.
+    size_factor_mode : str, default "total"
+        Mode passed to :func:`omvqvae.data.normalize.compute_size_factors` when
+        ``size_factors`` is not given.
+    batch_size : int, default 1024
+        Number of cells encoded per forward pass.
+
+    Returns
+    -------
+    EncodedCells
+        The discrete codes, the size factors used, and the continuous latent.
+
+    Raises
+    ------
+    ValueError
+        If ``counts`` is not 2-D, its gene dimension disagrees with
+        ``model.n_genes``, or ``size_factors`` has the wrong length.
+    """
+    dense = _counts_to_array(counts)
+    if dense.shape[1] != model.n_genes:
+        raise ValueError(
+            f"counts has {dense.shape[1]} genes but the model expects "
+            f"{model.n_genes}."
+        )
+    factors = _resolve_size_factors(dense, size_factors, size_factor_mode)
+
+    n_cells = dense.shape[0]
+    counts_t = torch.from_numpy(np.ascontiguousarray(dense, dtype=np.float32))
+    codes = torch.empty((n_cells, model.n_codebooks), dtype=torch.long)
+    latent = torch.empty((n_cells, model.n_latent), dtype=torch.float32)
+
+    with _inference_mode(model):
+        for start in range(0, n_cells, batch_size):
+            stop = min(start + batch_size, n_cells)
+            z = model.encode(counts_t[start:stop])
+            codes[start:stop] = model.quantize(z).indices
+            latent[start:stop] = z
+
+    return EncodedCells(codes=codes, size_factors=factors, latent=latent)
+
+
+def encode_anndata(
+    loaded: "LoadedModel",
+    adata: "AnnData",
+    *,
+    layer: Optional[str] = None,
+    var_key: Optional[str] = None,
+    min_overlap: float = 0.0,
+    size_factor_mode: str = "total",
+    batch_size: int = 1024,
+) -> EncodedCells:
+    """
+    Encode a local AnnData to discrete codes on the model's feature space.
+
+    The AnnData is aligned to the model's
+    :class:`~omvqvae.data.dataset.GeneVocabulary` (missing genes zero-filled,
+    extra genes dropped) before encoding, so it works regardless of the file's
+    own gene ordering.
+
+    Parameters
+    ----------
+    loaded : LoadedModel
+        A model + its gene vocabulary as returned by
+        :func:`omvqvae.hf_utils.load_pretrained` / ``from_pretrained``.
+    adata : anndata.AnnData
+        Cells to encode (raw counts).
+    layer : str, optional
+        AnnData layer to read counts from (default ``adata.X``).
+    var_key : str, optional
+        ``adata.var`` column providing gene ids (default ``var_names``).
+    min_overlap : float, default 0.0
+        Warn-below threshold for reference-gene coverage during alignment.
+    size_factor_mode : str, default "total"
+        Size-factor mode (see :func:`omvqvae.data.normalize.compute_size_factors`).
+        Size factors are computed from the **aligned** counts.
+    batch_size : int, default 1024
+        Number of cells encoded per forward pass.
+
+    Returns
+    -------
+    EncodedCells
+        The discrete codes, the size factors used, and the continuous latent.
+    """
+    matrix, gene_ids = extract_counts(adata, layer=layer, var_key=var_key)
+    aligned = align_to_reference(
+        matrix, gene_ids, loaded.vocabulary, min_overlap=min_overlap
+    )
+    return encode(
+        loaded.model,
+        aligned,
+        size_factor_mode=size_factor_mode,
+        batch_size=batch_size,
+    )
+
+
+def _resolve_codes(
+    codes: CodesLike,
+    size_factors: Optional[SizeFactorsLike],
+    n_codebooks: int,
+) -> tuple[Tensor, Tensor]:
+    """Normalize a codes argument (+ size factors) into aligned tensors."""
+    resolved_sf: Optional[SizeFactorsLike]
+    if isinstance(codes, EncodedCells):
+        codes_t = codes.codes
+        resolved_sf = codes.size_factors if size_factors is None else size_factors
+    else:
+        codes_t = torch.as_tensor(codes)
+        resolved_sf = size_factors
+    codes_t = codes_t.to(torch.long)
+    if codes_t.ndim != 2:
+        raise ValueError(
+            f"codes must be 2-D (n_cells, n_codebooks); got {codes_t.ndim}-D."
+        )
+    if codes_t.shape[1] != n_codebooks:
+        raise ValueError(
+            f"codes has {codes_t.shape[1]} levels but the model has "
+            f"{n_codebooks} codebooks."
+        )
+    if resolved_sf is None:
+        raise ValueError(
+            "size_factors is required when decoding from a raw codes array "
+            "(pass an EncodedCells bundle to reuse its size factors)."
+        )
+    if isinstance(resolved_sf, Tensor):
+        sf = resolved_sf.detach().cpu().to(torch.float32)
+    else:
+        sf = torch.as_tensor(np.asarray(resolved_sf, dtype=np.float32))
+    sf = sf.reshape(-1)
+    if sf.shape[0] != codes_t.shape[0]:
+        raise ValueError(
+            f"size_factors has length {sf.shape[0]} but there are "
+            f"{codes_t.shape[0]} cells."
+        )
+    return codes_t, sf
+
+
+def decode(
+    model: "OmicsVQVAE",
+    codes: CodesLike,
+    size_factors: Optional[SizeFactorsLike] = None,
+    *,
+    batch_size: int = 1024,
+) -> Tensor:
+    """
+    Decode discrete codes back to expected expression.
+
+    Parameters
+    ----------
+    model : OmicsVQVAE
+        The trained model the codes were produced by (same codebooks).
+    codes : torch.Tensor, numpy.ndarray, or EncodedCells
+        Per-cell codes of shape ``(n_cells, n_codebooks)`` (``int64``), or an
+        :class:`EncodedCells` bundle (whose ``size_factors`` are used unless
+        overridden).
+    size_factors : torch.Tensor or numpy.ndarray, optional
+        Per-cell size factors of shape ``(n_cells,)``. Required for a raw codes
+        array; defaults to the bundle's factors when ``codes`` is an
+        :class:`EncodedCells`.
+    batch_size : int, default 1024
+        Number of cells decoded per forward pass.
+
+    Returns
+    -------
+    torch.Tensor
+        The reconstruction mean of shape ``(n_cells, n_genes)`` (expected counts
+        for NB/ZINB; ``log1p`` expression for the Gaussian head).
+
+    Raises
+    ------
+    ValueError
+        If ``codes`` is not 2-D, its level count disagrees with the model, or
+        size factors are missing / mismatched.
+    """
+    codes_t, sf = _resolve_codes(codes, size_factors, model.n_codebooks)
+    n_cells = codes_t.shape[0]
+    out = torch.empty((n_cells, model.n_genes), dtype=torch.float32)
+    with _inference_mode(model):
+        for start in range(0, n_cells, batch_size):
+            stop = min(start + batch_size, n_cells)
+            out[start:stop] = model.decode_codes(codes_t[start:stop], sf[start:stop])
+    return out
+
+
+def decode_to_params(
+    model: "OmicsVQVAE",
+    codes: CodesLike,
+    size_factors: Optional[SizeFactorsLike] = None,
+) -> Dict[str, Tensor]:
+    """
+    Decode discrete codes to the full reconstruction-likelihood parameters.
+
+    Unlike :func:`decode` (which returns only the mean), this exposes every
+    per-gene distribution parameter of the configured head — useful for sampling
+    synthetic profiles or inspecting dispersion / dropout.
+
+    Parameters
+    ----------
+    model : OmicsVQVAE
+        The trained model the codes were produced by.
+    codes : torch.Tensor, numpy.ndarray, or EncodedCells
+        Per-cell codes of shape ``(n_cells, n_codebooks)``, or an
+        :class:`EncodedCells` bundle.
+    size_factors : torch.Tensor or numpy.ndarray, optional
+        Per-cell size factors; defaults to the bundle's factors when ``codes`` is
+        an :class:`EncodedCells`.
+
+    Returns
+    -------
+    Dict[str, torch.Tensor]
+        The per-gene distribution parameters (see the configured head).
+    """
+    codes_t, sf = _resolve_codes(codes, size_factors, model.n_codebooks)
+    with _inference_mode(model):
+        return model.codes_to_params(codes_t, sf)

--- a/src/omvqvae/layers/residual_vq.py
+++ b/src/omvqvae/layers/residual_vq.py
@@ -37,7 +37,7 @@ Design notes
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List
+from typing import List, Optional, cast
 
 import torch
 from torch import Tensor, nn
@@ -215,6 +215,27 @@ class VectorQuantizer(nn.Module):
         """Return the codebook tensor (buffer under EMA, parameter otherwise)."""
         embedding: Tensor = self.embedding
         return embedding
+
+    def lookup(self, indices: Tensor) -> Tensor:
+        """
+        Map codebook indices back to their codebook vectors.
+
+        This is the inverse of the assignment step in :meth:`forward`: it embeds
+        discrete indices without computing distances or losses, so a stored code
+        can be turned back into its quantized vector for decoding/generation.
+
+        Parameters
+        ----------
+        indices : torch.Tensor
+            Codebook indices of arbitrary shape (``int64``); each value must lie
+            in ``[0, codebook_size)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Codebook vectors of shape ``indices.shape + (embedding_dim,)``.
+        """
+        return self._codebook()[indices]
 
     def forward(self, inputs: Tensor) -> QuantizerOutput:
         """
@@ -399,6 +420,45 @@ class ResidualVQ(nn.Module):
             )
             for _ in range(n_codebooks)
         )
+
+    def lookup(self, indices: Tensor) -> Tensor:
+        """
+        Reconstruct the summed quantized vector from per-level codebook indices.
+
+        This inverts the index half of :meth:`forward`: it maps a cell's discrete
+        code (one index per residual level) back to the summed quantized latent
+        that the decoder consumes, without recomputing the encoder/residuals.
+
+        Parameters
+        ----------
+        indices : torch.Tensor
+            Per-level codebook indices of shape ``(..., n_codebooks)``
+            (``int64``), as returned in :attr:`ResidualVQOutput.indices`.
+
+        Returns
+        -------
+        torch.Tensor
+            Summed quantized vectors of shape
+            ``indices.shape[:-1] + (embedding_dim,)``.
+
+        Raises
+        ------
+        ValueError
+            If the last dimension of ``indices`` is not ``n_codebooks``.
+        """
+        if indices.shape[-1] != self.n_codebooks:
+            raise ValueError(
+                f"indices last dim {indices.shape[-1]} != n_codebooks "
+                f"{self.n_codebooks}."
+            )
+        quantized: Optional[Tensor] = None
+        for level in range(self.n_codebooks):
+            quantizer = cast(VectorQuantizer, self.quantizers[level])
+            vectors = quantizer.lookup(indices[..., level])
+            quantized = vectors if quantized is None else quantized + vectors
+        # ``n_codebooks >= 1`` is enforced in ``__init__`` so the loop always runs.
+        assert quantized is not None
+        return quantized
 
     def forward(self, inputs: Tensor) -> ResidualVQOutput:
         """

--- a/src/omvqvae/layers/residual_vq.py
+++ b/src/omvqvae/layers/residual_vq.py
@@ -37,7 +37,7 @@ Design notes
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List, Optional, cast
+from typing import List, cast
 
 import torch
 from torch import Tensor, nn
@@ -451,13 +451,13 @@ class ResidualVQ(nn.Module):
                 f"indices last dim {indices.shape[-1]} != n_codebooks "
                 f"{self.n_codebooks}."
             )
-        quantized: Optional[Tensor] = None
-        for level in range(self.n_codebooks):
+        # ``n_codebooks >= 1`` is enforced in ``__init__``, so seed the sum with
+        # the first level and accumulate the rest (no Optional / assert needed).
+        first = cast(VectorQuantizer, self.quantizers[0])
+        quantized = first.lookup(indices[..., 0])
+        for level in range(1, self.n_codebooks):
             quantizer = cast(VectorQuantizer, self.quantizers[level])
-            vectors = quantizer.lookup(indices[..., level])
-            quantized = vectors if quantized is None else quantized + vectors
-        # ``n_codebooks >= 1`` is enforced in ``__init__`` so the loop always runs.
-        assert quantized is not None
+            quantized = quantized + quantizer.lookup(indices[..., level])
         return quantized
 
     def forward(self, inputs: Tensor) -> ResidualVQOutput:

--- a/src/omvqvae/models/vqvae.py
+++ b/src/omvqvae/models/vqvae.py
@@ -390,6 +390,54 @@ class OmicsVQVAE(nn.Module):
         """Return the reconstruction mean for a quantized latent."""
         return self.head.expected_counts(self.decoder_body(quantized), size_factors)
 
+    def codes_to_params(self, codes: Tensor, size_factors: Tensor) -> Dict[str, Tensor]:
+        """
+        Decode discrete codes to the reconstruction-likelihood parameters.
+
+        Inverts the index half of :meth:`encode_codes`: the per-level codebook
+        indices are mapped back to the summed quantized latent
+        (:meth:`~omvqvae.layers.residual_vq.ResidualVQ.lookup`) and decoded to the
+        per-gene distribution parameters.
+
+        Parameters
+        ----------
+        codes : torch.Tensor
+            Per-level codebook indices of shape ``(batch, n_codebooks)``
+            (``int64``).
+        size_factors : torch.Tensor
+            Per-cell size factors of shape ``(batch,)``.
+
+        Returns
+        -------
+        Dict[str, torch.Tensor]
+            The per-gene distribution parameters (see the configured head).
+        """
+        return self.decode(self.rvq.lookup(codes), size_factors)
+
+    def decode_codes(self, codes: Tensor, size_factors: Tensor) -> Tensor:
+        """
+        Reconstruct expected counts directly from discrete codes.
+
+        Inverse of :meth:`encode_codes`: maps a cell's per-level codebook indices
+        back to the summed quantized latent and decodes it to the reconstruction
+        mean (depth-appropriate expected counts for NB/ZINB; ``log1p`` expression
+        for the Gaussian head).
+
+        Parameters
+        ----------
+        codes : torch.Tensor
+            Per-level codebook indices of shape ``(batch, n_codebooks)``
+            (``int64``).
+        size_factors : torch.Tensor
+            Per-cell size factors of shape ``(batch,)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Reconstruction mean of shape ``(batch, n_genes)``.
+        """
+        return self.expected_counts(self.rvq.lookup(codes), size_factors)
+
     def forward(self, counts: Tensor, size_factors: Tensor) -> VQVAEOutput:
         """
         Encode, quantize, decode, and compose the loss for a batch.

--- a/tests/inference/test_codes.py
+++ b/tests/inference/test_codes.py
@@ -1,0 +1,327 @@
+"""
+Tests for the discrete-code inference API (:mod:`omvqvae.inference.codes`).
+
+Offline and synthetic: the ``encode → decode`` round-trip, the codes/size-factor
+formats, alignment of local AnnData, eval-mode side-effect freedom, and the
+validation/error paths. Also covers the new code→vector inverse helpers on the
+quantizer and model.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+import numpy as np
+import pytest
+import torch
+from anndata import AnnData
+from scipy import sparse
+
+from omvqvae.data.dataset import GeneVocabulary
+from omvqvae.hf_utils import LoadedModel
+from omvqvae.inference import (
+    EncodedCells,
+    decode,
+    decode_to_params,
+    encode,
+    encode_anndata,
+)
+from omvqvae.layers.residual_vq import ResidualVQ
+from omvqvae.models.vqvae import OmicsVQVAE
+
+GENE_IDS = ["ENSG1", "ENSG2", "ENSG3", "ENSG4", "ENSG5"]
+
+
+def _model(seed: int = 0, *, likelihood: str = "nb") -> OmicsVQVAE:
+    torch.manual_seed(seed)
+    return OmicsVQVAE(
+        len(GENE_IDS),
+        n_latent=6,
+        hidden_dims=(16,),
+        likelihood=likelihood,
+        codebook_size=8,
+        n_codebooks=3,
+    )
+
+
+def _counts(n_cells: int = 7, *, seed: int = 1) -> torch.Tensor:
+    rng = np.random.default_rng(seed)
+    counts = rng.poisson(lam=3.0, size=(n_cells, len(GENE_IDS))).astype(np.float32)
+    return torch.from_numpy(counts)
+
+
+def _make_anndata(
+    gene_ids: List[str], *, n_cells: int = 5, seed: int = 2, sparse_x: bool = True
+) -> AnnData:
+    import pandas as pd
+
+    rng = np.random.default_rng(seed)
+    counts = rng.poisson(lam=2.0, size=(n_cells, len(gene_ids))).astype(np.float32)
+    x: object = sparse.csr_matrix(counts) if sparse_x else counts
+    obs = pd.DataFrame(index=[f"cell_{i}" for i in range(n_cells)])
+    var = pd.DataFrame(index=list(gene_ids))
+    return AnnData(X=x, obs=obs, var=var)
+
+
+# --------------------------------------------------------------------------- #
+# Layer / model inverse helpers
+# --------------------------------------------------------------------------- #
+def test_vector_quantizer_lookup_matches_forward() -> None:
+    model = _model()
+    counts = _counts()
+    model.eval()
+    latent = model.encode(counts)
+    vq = model.quantize(latent)
+    # The summed quantized vector reconstructed from indices equals the forward
+    # pass' quantized output.
+    recon = model.rvq.lookup(vq.indices)
+    assert torch.allclose(recon, vq.quantized, atol=1e-6)
+
+
+def test_residual_vq_lookup_rejects_wrong_levels() -> None:
+    rvq = ResidualVQ(codebook_size=4, embedding_dim=3, n_codebooks=2)
+    with pytest.raises(ValueError):
+        rvq.lookup(torch.zeros((5, 3), dtype=torch.long))
+
+
+def test_model_decode_codes_matches_expected_counts() -> None:
+    model = _model()
+    counts = _counts()
+    sf = counts.sum(dim=1)
+    model.eval()
+    codes = model.encode_codes(counts)
+    quantized = model.rvq.lookup(codes)
+    direct = model.expected_counts(quantized, sf)
+    via_codes = model.decode_codes(codes, sf)
+    assert torch.allclose(direct, via_codes, atol=1e-6)
+    params = model.codes_to_params(codes, sf)
+    # px_scale/px_rate are per-cell-per-gene; theta is gene-wise.
+    assert params["px_rate"].shape == counts.shape
+
+
+# --------------------------------------------------------------------------- #
+# encode
+# --------------------------------------------------------------------------- #
+def test_encode_shapes_and_dtypes() -> None:
+    model = _model()
+    counts = _counts(n_cells=7)
+    enc = encode(model, counts)
+    assert isinstance(enc, EncodedCells)
+    assert enc.codes.shape == (7, model.n_codebooks)
+    assert enc.codes.dtype == torch.long
+    assert enc.size_factors.shape == (7,)
+    assert enc.latent.shape == (7, model.n_latent)
+    assert len(enc) == 7
+    # Default size factors are the per-cell totals ("total" mode).
+    assert torch.allclose(enc.size_factors, counts.sum(dim=1))
+
+
+def test_encode_matches_model_encode_codes() -> None:
+    model = _model()
+    counts = _counts()
+    model.eval()
+    expected = model.encode_codes(counts)
+    enc = encode(model, counts)
+    assert torch.equal(enc.codes, expected)
+
+
+def test_encode_batched_equals_unbatched() -> None:
+    model = _model()
+    counts = _counts(n_cells=10)
+    full = encode(model, counts, batch_size=100)
+    chunked = encode(model, counts, batch_size=3)
+    assert torch.equal(full.codes, chunked.codes)
+    assert torch.allclose(full.latent, chunked.latent, atol=1e-6)
+
+
+def test_encode_accepts_numpy_and_sparse() -> None:
+    model = _model()
+    counts = _counts()
+    from_np = encode(model, counts.numpy())
+    from_sparse = encode(model, sparse.csr_matrix(counts.numpy()))
+    assert torch.equal(from_np.codes, from_sparse.codes)
+
+
+def test_encode_explicit_size_factors() -> None:
+    model = _model()
+    counts = _counts(n_cells=4)
+    sf = np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32)
+    enc = encode(model, counts, size_factors=sf)
+    assert torch.allclose(enc.size_factors, torch.from_numpy(sf))
+
+
+def test_encode_size_factor_tensor() -> None:
+    model = _model()
+    counts = _counts(n_cells=3)
+    sf = torch.tensor([5.0, 6.0, 7.0])
+    enc = encode(model, counts, size_factors=sf)
+    assert torch.allclose(enc.size_factors, sf)
+
+
+def test_encode_empty_input() -> None:
+    model = _model()
+    enc = encode(model, torch.zeros((0, len(GENE_IDS))))
+    assert enc.codes.shape == (0, model.n_codebooks)
+    assert enc.size_factors.shape == (0,)
+
+
+def test_encode_gene_mismatch_raises() -> None:
+    model = _model()
+    with pytest.raises(ValueError, match="genes"):
+        encode(model, torch.zeros((2, len(GENE_IDS) + 1)))
+
+
+def test_encode_non_2d_raises() -> None:
+    model = _model()
+    with pytest.raises(ValueError, match="2-D"):
+        encode(model, torch.zeros((2, 3, 4)))
+
+
+def test_encode_wrong_size_factor_length_raises() -> None:
+    model = _model()
+    counts = _counts(n_cells=4)
+    with pytest.raises(ValueError, match="length"):
+        encode(model, counts, size_factors=np.ones(3, dtype=np.float32))
+
+
+def test_encode_does_not_mutate_training_mode() -> None:
+    model = _model()
+    model.train()
+    quantizer = model.rvq.quantizers[0]
+    codebook_before = quantizer.embedding.clone()  # type: ignore[union-attr]
+    encode(model, _counts())
+    # Model is left in training mode and EMA codebooks are untouched.
+    assert model.training
+    assert torch.equal(quantizer.embedding, codebook_before)  # type: ignore[union-attr]
+
+
+# --------------------------------------------------------------------------- #
+# decode + round-trip
+# --------------------------------------------------------------------------- #
+def test_round_trip_encode_decode() -> None:
+    model = _model()
+    counts = _counts(n_cells=6)
+    enc = encode(model, counts)
+    recon = decode(model, enc)
+    assert recon.shape == counts.shape
+    assert torch.isfinite(recon).all()
+    # NB mean is non-negative.
+    assert (recon >= 0).all()
+
+
+def test_decode_held_out_cells_round_trip() -> None:
+    # Held-out cells: encode then decode reproduces the same codes when re-encoded
+    # from the decoder's mean is not expected, but decoding the stored codes is
+    # deterministic and depth-appropriate.
+    model = _model()
+    counts = _counts(n_cells=8, seed=99)
+    enc = encode(model, counts)
+    recon_a = decode(model, enc.codes, enc.size_factors)
+    recon_b = decode(model, enc)
+    assert torch.allclose(recon_a, recon_b, atol=1e-6)
+
+
+def test_decode_batched_equals_unbatched() -> None:
+    model = _model()
+    counts = _counts(n_cells=11)
+    enc = encode(model, counts)
+    full = decode(model, enc, batch_size=100)
+    chunked = decode(model, enc, batch_size=4)
+    assert torch.allclose(full, chunked, atol=1e-6)
+
+
+def test_decode_accepts_numpy_codes() -> None:
+    model = _model()
+    counts = _counts(n_cells=5)
+    enc = encode(model, counts)
+    recon = decode(model, enc.codes.numpy(), enc.size_factors.numpy())
+    assert recon.shape == counts.shape
+
+
+def test_decode_size_factor_scales_counts() -> None:
+    # Larger size factor → larger expected counts for the same NB code.
+    model = _model()
+    counts = _counts(n_cells=3)
+    enc = encode(model, counts)
+    small = decode(model, enc.codes, torch.full((3,), 10.0))
+    large = decode(model, enc.codes, torch.full((3,), 100.0))
+    assert large.sum() > small.sum()
+
+
+def test_decode_override_size_factors_on_bundle() -> None:
+    model = _model()
+    counts = _counts(n_cells=3)
+    enc = encode(model, counts)
+    override = torch.full((3,), 50.0)
+    recon = decode(model, enc, override)
+    direct = model.decode_codes(enc.codes, override)
+    assert torch.allclose(recon, direct, atol=1e-6)
+
+
+def test_decode_missing_size_factors_raises() -> None:
+    model = _model()
+    with pytest.raises(ValueError, match="size_factors is required"):
+        decode(model, torch.zeros((2, model.n_codebooks), dtype=torch.long))
+
+
+def test_decode_non_2d_codes_raises() -> None:
+    model = _model()
+    with pytest.raises(ValueError, match="2-D"):
+        decode(model, torch.zeros((2, 3, model.n_codebooks), dtype=torch.long))
+
+
+def test_decode_wrong_level_count_raises() -> None:
+    model = _model()
+    bad = torch.zeros((2, model.n_codebooks + 1), dtype=torch.long)
+    with pytest.raises(ValueError, match="levels"):
+        decode(model, bad, torch.ones(2))
+
+
+def test_decode_size_factor_mismatch_raises() -> None:
+    model = _model()
+    codes = torch.zeros((3, model.n_codebooks), dtype=torch.long)
+    with pytest.raises(ValueError, match="length"):
+        decode(model, codes, torch.ones(2))
+
+
+def test_decode_to_params_returns_head_parameters() -> None:
+    model = _model(likelihood="zinb")
+    counts = _counts(n_cells=4)
+    enc = encode(model, counts)
+    params = decode_to_params(model, enc)
+    assert set(params)
+    # The per-cell-per-gene mean is present with the expected shape.
+    assert params["px_rate"].shape == (4, len(GENE_IDS))
+
+
+# --------------------------------------------------------------------------- #
+# encode_anndata
+# --------------------------------------------------------------------------- #
+def _loaded(model: OmicsVQVAE) -> LoadedModel:
+    vocab = GeneVocabulary("homo_sapiens", GENE_IDS)
+    return LoadedModel(model=model, vocabulary=vocab)
+
+
+def test_encode_anndata_round_trip() -> None:
+    model = _model()
+    adata = _make_anndata(GENE_IDS, n_cells=5)
+    enc = encode_anndata(_loaded(model), adata)
+    assert enc.codes.shape == (5, model.n_codebooks)
+    recon = decode(model, enc)
+    assert recon.shape == (5, len(GENE_IDS))
+
+
+def test_encode_anndata_aligns_reordered_and_missing_genes() -> None:
+    model = _model()
+    # AnnData with a permuted subset + an extra unknown gene; alignment should
+    # zero-fill the missing reference gene and drop the extra.
+    file_genes = ["ENSG3", "ENSG1", "EXTRA", "ENSG2", "ENSG4"]
+    adata = _make_anndata(file_genes, n_cells=4)
+    enc = encode_anndata(_loaded(model), adata)
+    assert enc.codes.shape == (4, model.n_codebooks)
+    # Re-encoding the aligned dense counts directly gives identical codes.
+    from omvqvae.data.dataset import align_to_reference
+
+    aligned = align_to_reference(adata.X, file_genes, _loaded(model).vocabulary)
+    direct = encode(model, aligned)
+    assert torch.equal(enc.codes, direct.codes)


### PR DESCRIPTION
## PR #7 — Discrete-code inference API

The user-facing discrete-latent interface on top of a trained `OmicsVQVAE` + HF loading. Closes the Phase 3 PR #7 item from the roadmap.

```
counts ──encode──► codes (n_cells, n_codebooks)  ──decode──► expected counts
                   + per-cell size factor
```

### What's new

**`omvqvae.inference` (`inference/codes.py`)**
- `encode(model, counts, ...) → EncodedCells` — raw counts (tensor / ndarray / sparse) → discrete codes.
- `encode_anndata(loaded, adata, ...) → EncodedCells` — aligns a local AnnData to the model's `GeneVocabulary` (`align_to_reference`: zero-fill missing, drop extra) before encoding, so it works regardless of the file's gene ordering.
- `decode(model, codes_or_bundle, size_factors=None) → expected counts`; `decode_to_params(...)` exposes the full head distribution (for sampling/generation).
- All inference runs in `eval` + `no_grad` (EMA codebooks / dead-code stats **not** mutated) and restores the model's prior train/eval mode; `encode`/`decode` are batched.

**Code-vector format** — `EncodedCells.codes` is an `int64` `(n_cells, n_codebooks)` tensor: row = a cell's discrete code, column `j` = the index chosen from residual codebook `j` (in `[0, codebook_size)`). Decoding additionally needs a per-cell `size_factor` (observed depth), which `encode` returns alongside the codes; `decode` reuses the bundle's factors unless overridden. The bundle also carries the continuous pre-quantization `latent` for quantization-error inspection.

**Inverse path on the layer/model** (so inference doesn't poke internals)
- `VectorQuantizer.lookup` / `ResidualVQ.lookup` — indices → summed quantized vector.
- `OmicsVQVAE.decode_codes` / `codes_to_params` — codes → expected counts / head params.

### Testing
- No new deps; `uv.lock` unchanged.
- Offline tests at **100% coverage** on `inference/codes.py`: held-out encode→decode round-trip, batched == unbatched, numpy/sparse inputs, AnnData alignment (reordered / missing / extra genes), size-factor scaling, eval-mode side-effect freedom, and every validation/error path; plus `lookup` / `decode_codes` unit tests.
- `make ci` green (black, isort, flake8, mypy strict, pytest) at ~99.7% total coverage.

### Docs
- `docs/STATUS.md` + `docs/PROJECT_PLAN.md`: mark PR #7 done, set **PR #8 (examples & documentation)** as next, and log the design decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013QJ2fWejWHGEFpY8TSPF4b

---
_Generated by [Claude Code](https://claude.ai/code/session_013QJ2fWejWHGEFpY8TSPF4b)_