### PR TITLE
docs(examples): runnable OQAE example scripts (PR #8 slice 1)

### DIFF
--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -327,10 +327,17 @@ src/omvqvae/
   documented code-vector format (see `inference/codes.py` module docstring); 100%
   offline coverage on the module; `make ci` green.
 
-#### **PR #8: Examples & Documentation**
-- **Scope**: notebooks (Census streaming, local fine-tuning, code
+#### **PR #8: Examples & Documentation — 🚧 IN PROGRESS (slice 1 done)**
+- **Scope**: examples (Census streaming, local fine-tuning, code
   inspection/generation), Sphinx docs.
-- **Exit criteria**: docs build; examples run on small data.
+- **Status**: *Slice 1* (example scripts) **DONE** — `examples/` holds three
+  runnable scripts (`01_train_local_anndata.py`,
+  `02_inspect_and_generate_codes.py`, `03_census_streaming.py`), a `README.md`,
+  and a shared offline `synthetic_data.py` helper; offline examples are
+  smoke-tested in `tests/test_examples.py`. *Slice 2* (Sphinx docs scaffold +
+  autodoc of the public API) is next.
+- **Exit criteria**: docs build; examples run on small data. Examples met
+  (offline, CI-tested); the docs build is slice 2.
 
 #### **PR #9: Benchmarking & Scaling**
 - **Scope**: raw-count+NB vs log-normalized+Gaussian comparison; codebook
@@ -425,6 +432,7 @@ A running record of decisions so future sessions don't re-litigate them.
 | 2026-06-22 | **`OmicsVQVAE` = symmetric MLP encoder/decoder around `ResidualVQ` + a `ReconstructionHead`.** Encoder input is internally `log1p`-transformed for numerical stability; the reconstruction *target* is raw counts for NB/ZINB and `log1p` expression for the Gaussian head. Decoder hidden widths mirror the encoder (`hidden_dims` reversed); the head consumes the final decoder hidden dim. `forward` returns a `VQVAEOutput` composing recon + VQ loss with the per-level codes and codebook metrics. Total loss = `reconstruction_loss + vq.loss` (per-cell-mean recon NLL + mean VQ loss), unweighted in v1. | Keeps depth/normalization handling inside the model and count statistics intact; one symmetric, configurable module covers all three likelihoods. The `VQVAEOutput` bundle hands PR #5 its loss + W&B monitoring signals without coupling to the layer internals. Loss-term weighting is left as a future tuning knob. |
 | 2026-06-25 | **HF serialization = self-describing model + a HuggingFace-style directory.** Added `OmicsVQVAE.get_config()` / `from_config()` (the model carries every constructor hyper-parameter), so `hf_utils.save_pretrained` writes `config.json` (`{format_version, organism, gene_ids, model=get_config(), experiment_config}`) + `pytorch_model.bin` and `load_pretrained` rebuilds the exact model/feature space — decoupled from the training CLI. `hf_utils.py` lives at the **package top level** (per the package-structure diagram, not under `models/` or `inference/`). `from_checkpoint` converts a CLI `{state_dict, organism, gene_ids, config}` bundle into the same directory shape so both share one format; `push_to_hub` / `from_pretrained` are thin `huggingface_hub` shells (`# pragma: no cover`, network-gated) wrapping the tested pure save/load step. Added direct dep `huggingface-hub>=0.20.0` (already transitive via `transformers`). | Making the model self-describing is the standard HF `PreTrainedModel` pattern and keeps serialization independent of `train.cli`/OmegaConf. A plain JSON+weights directory *is* a Hub-ready repo and is fully offline-testable, leaving only upload/download as the networked edge. Reusing the CLI bundle's architecture fields via `from_checkpoint` avoids two divergent on-disk formats. |
 | 2026-06-26 | **Discrete-code inference API = free functions over a trained model returning an `EncodedCells` bundle, with the code→vector inverse path pushed into the layer/model.** `inference/codes.py` exposes `encode`/`encode_anndata` (→ `EncodedCells{codes (n_cells, n_codebooks) int64, size_factors, latent}`) and `decode`/`decode_to_params`. The codes alone don't reconstruct depth — decoding needs a per-cell `size_factor`, so `encode` returns it in the bundle and `decode` reuses it (overridable). The inverse `indices → summed quantized vector` is a tested `ResidualVQ.lookup` / `OmicsVQVAE.decode_codes` method rather than reaching into codebook buffers. All inference forces `eval` + `no_grad` (so EMA/dead-code stats aren't mutated) and restores the prior mode; `encode`/`decode` are batched. `encode_anndata` takes a `LoadedModel` and aligns via `align_to_reference` (annotation under `TYPE_CHECKING` to avoid an import cycle / heavy import). | Free functions keep the API thin and match the functional style of the data/train layers; the `EncodedCells` bundle makes the codes+size-factor pair (the actual compressed representation) explicit and gives a frictionless `decode(model, encode(model, x))` round-trip. Putting `lookup`/`decode_codes` on the layer/model keeps inference decoupled from quantizer internals and is reusable by generation/benchmarking PRs. Forcing eval/no_grad prevents inference from silently drifting the codebooks. |
+| 2026-06-27 | **Examples = standalone runnable scripts under `examples/` (not notebooks), smoke-tested offline.** Three scripts share one synthetic-data helper (`synthetic_data.py`): local-AnnData training+`save_pretrained` (1), the full `omvqvae.inference` encode→inspect→decode→generate walk via a `save_pretrained`/`load_pretrained` round-trip (2), and Census streaming (3, network-gated). Each exposes a `main()`; `tests/test_examples.py` imports them via `importlib` and runs the offline ones end to end (example 3's `main` only under `@pytest.mark.network`). Examples live outside the `src` coverage scope, so they don't move the coverage gate. Split PR #8 into slices: scripts first (this PR), Sphinx docs second. | Plain `.py` scripts are diffable, lint/format-clean, and — unlike notebooks — runnable in CI with no `nbconvert`/`jupyter` execution layer, so the documented workflows are guaranteed to keep working. A shared synthetic helper keeps them tiny and offline. Reusing `save_pretrained`/`load_pretrained` in example 2 also exercises the HF round-trip the way a real user would (`from_pretrained` → `LoadedModel` → `encode_anndata`). Slicing keeps each run to one CI-verifiable chunk; the Sphinx scaffold needs new docs deps + a build target and slots in next. |
 | 2026-06-24 | **Training CLI = OmegaConf structured config + a single-command typer app (`oqae-train`).** The config schema is plain dataclasses (`ExperimentConfig`/`ModelConfig`/`DataConfig`/`TrainingConfig`/`TrackingConfig`) so OmegaConf validates the YAML, rejects unknown keys, and supports `--set a.b=c` dot-list overrides; `OmegaConf.to_object` yields typed objects for mypy. Pure builders (`build_model`/`build_train_config`/`build_tracker_from_config`/`build_data`) map one config section → one object and `run_experiment` wires them, so the config→objects path is unit-tested offline. The **local-AnnData** source derives its `GeneVocabulary` (hence the model's `n_genes`) from the file's own genes; the **Census** source is the one networked branch (`# pragma: no cover`). The optional checkpoint stores `{state_dict, organism, gene_ids, config}`. | A declarative, schema-checked config keeps runs reproducible and overridable from the shell; the pure-builder split keeps the heavy/networked I/O at the edges and everything else offline-testable (incl. via Typer's `CliRunner`). Persisting `gene_ids`/`organism`/`config` alongside the weights is what PR #6 (HF Hub) and PR #7 (inference) need to reload a model against the right feature space. Single-command typer means `oqae-train config.yaml` with no redundant subcommand name. |
 
 ## 🔄 **Future Roadmap (Post-v1.0)**
@@ -442,12 +450,11 @@ A running record of decisions so future sessions don't re-litigate them.
 
 ---
 
-**Last Updated**: 2026-06-26 — PR #7 complete: `omvqvae.inference`
-(`inference/codes.py`) is the discrete-code latent API — `encode`/`encode_anndata`
-→ `EncodedCells` (codes + size factors + latent), `decode`/`decode_to_params` →
-expression, with the code→vector inverse path (`ResidualVQ.lookup` /
-`OmicsVQVAE.decode_codes`) on the layer/model.
-**Current Focus**: PR #8 — examples & documentation (notebooks for Census
-streaming / local fine-tuning / code inspection + generation; Sphinx docs; see
-`docs/STATUS.md`).
-**Next Review**: After PR #8 (examples & documentation).
+**Last Updated**: 2026-06-27 — PR #8 slice 1 complete: `examples/` holds three
+runnable scripts (local-AnnData training, the encode→inspect→decode→generate
+inference walk, and Census streaming) over a shared offline synthetic-data
+helper, smoke-tested in `tests/test_examples.py`.
+**Current Focus**: PR #8 slice 2 — Sphinx docs scaffold (autodoc the public API:
+`data`, `layers`, `models`, `train`, `inference`, `hf_utils`,
+`utils.tracking`; getting-started page linking the examples); see `docs/STATUS.md`.
+**Next Review**: After PR #8 slice 2 (Sphinx documentation).

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -4,7 +4,7 @@
 > end of every working session** so the next session can pick up cold. Keep it
 > short; deep rationale lives in `docs/PROJECT_PLAN.md`.
 
-**Last updated:** 2026-06-26
+**Last updated:** 2026-06-27
 
 ## Current state
 
@@ -153,33 +153,46 @@
     validation/error path) plus `lookup`/`decode_codes` tests; `make ci` green
     (~99.7%).
 
-## Next task — PR #8: Examples & documentation
+- **PR #8 slice 1 (example scripts) — DONE (this PR).**
+  - `examples/` — three runnable, self-contained scripts plus a `README.md`
+    overview and a shared `synthetic_data.py` helper (a tiny raw-count AnnData
+    with latent "programs", offline). `01_train_local_anndata.py` trains an
+    `OmicsVQVAE` on a local AnnData (derive `GeneVocabulary` → `train` →
+    `save_pretrained`); `02_inspect_and_generate_codes.py` walks the full
+    `omvqvae.inference` API (`encode_anndata` → inspect codebook usage /
+    program structure → `decode` → `decode_to_params` → generate a novel profile
+    from edited codes, round-tripping through `save_pretrained`/`load_pretrained`);
+    `03_census_streaming.py` streams a Census slice (network-gated, same
+    `Minibatch` contract as example 1).
+  - `tests/test_examples.py` smoke-tests the offline examples end to end (each
+    `main()` runs on tiny synthetic data via `importlib`) and imports the Census
+    example to catch regressions (its `main` runs only under `@pytest.mark.network`).
+    Examples live under `examples/` (outside the `src` coverage scope), so they
+    don't affect the coverage gate; `make ci` green (~99.7%). No new deps.
 
-PR #7 is **DONE**. Next is PR #8 (Phase 3):
+## Next task — PR #8 slice 2: Sphinx documentation
 
-1. Example notebooks under `examples/` (or `docs/`): Census streaming training,
-   local `.h5ad` fine-tuning, and **code inspection / generation** using the new
-   `omvqvae.inference` API (`encode` → inspect codes → `decode` /
-   `decode_to_params`). Keep them runnable on tiny synthetic data so they don't
-   require network/Census.
-2. Sphinx docs scaffold (autodoc the public API: `data`, `layers`, `models`,
-   `train`, `inference`, `hf_utils`). Make `docs/` build.
+PR #8 slice 1 (example scripts) is **DONE**. Next is slice 2 — the Sphinx docs
+scaffold:
 
-**Definition of done:** docs build; examples run on small data; CI green; PR
-opened. Consider splitting into a slice (notebooks first, Sphinx second) if it
-grows beyond one PR-sized chunk.
+1. Add a Sphinx project under `docs/` (e.g. `docs/source/`) with `conf.py`
+   (autodoc + napoleon for the NumPy docstrings) and an index that autodocs the
+   public API: `data`, `layers`, `models`, `train`, `inference`, `hf_utils`,
+   `utils.tracking`.
+2. A short narrative/getting-started page linking the `examples/` scripts.
+3. Make `docs/` build (`sphinx-build` clean); wire a `make docs` target. Add the
+   docs deps (`sphinx`, a theme, e.g. `furo`/`sphinx-rtd-theme`) under a `docs`
+   extra and refresh `uv.lock` in the same PR.
 
-### Available building blocks (for PR #8)
+**Definition of done:** `docs/` build clean; CI green; PR opened. Decide whether
+to also add a CI job that builds the docs (optional — can defer to PR #10).
 
-- `omvqvae.inference`: `encode` / `encode_anndata` / `decode` /
-  `decode_to_params` / `EncodedCells` — the latent API the examples demonstrate.
-- `omvqvae.hf_utils`: `save_pretrained` / `load_pretrained` / `from_checkpoint` /
-  `push_to_hub` / `from_pretrained` → `LoadedModel`
-  (`model`/`vocabulary`/`experiment_config`).
-- `omvqvae.train`: `train` + `oqae-train` CLI (`run_experiment`, builders) and
-  `configs/train_toy.yaml` for the training examples.
-- `omvqvae.data`: `GeneVocabulary` / `align_to_reference` / `build_anndata_dataloader`
-  / `build_census_dataloader` for the data-loading examples.
+### Available building blocks (for PR #8 slice 2)
+
+- `examples/` — the runnable scripts to link from a getting-started page.
+- Public API to autodoc: `omvqvae.data`, `omvqvae.layers`, `omvqvae.models`,
+  `omvqvae.train`, `omvqvae.inference`, `omvqvae.hf_utils`,
+  `omvqvae.utils.tracking` (all NumPy-docstringed).
 
 ## Open questions / parked
 
@@ -198,6 +211,20 @@ grows beyond one PR-sized chunk.
 
 ## Changelog (most recent first)
 
+- **2026-06-27** — PR #8 slice 1: example scripts. Added `examples/` — three
+  runnable, self-contained scripts (`01_train_local_anndata.py`,
+  `02_inspect_and_generate_codes.py`, `03_census_streaming.py`), a `README.md`
+  overview, and a shared offline `synthetic_data.py` helper (tiny raw-count
+  AnnData with latent "programs"). Example 1 trains on a local AnnData and
+  `save_pretrained`s; example 2 walks the full `omvqvae.inference` API
+  (encode → inspect codebook usage / program structure → decode →
+  `decode_to_params` → generate from edited codes, via a
+  `save_pretrained`/`load_pretrained` round-trip); example 3 streams a Census
+  slice (network-gated). `tests/test_examples.py` smoke-tests the offline
+  examples end to end (importlib-driven `main()` on tiny data) and imports the
+  Census example (its `main` runs only under `@pytest.mark.network`). Examples
+  sit outside the `src` coverage scope, so the gate is unaffected; no new deps;
+  `make ci` green (~99.7%). Slice 2 (Sphinx docs) is the next chunk.
 - **2026-06-26** — PR #7: discrete-code inference API. Added the
   `omvqvae.inference` package (`inference/codes.py`): `encode` /
   `encode_anndata` turn raw counts / a local AnnData (aligned to the model's

--- a/examples/01_train_local_anndata.py
+++ b/examples/01_train_local_anndata.py
@@ -1,0 +1,107 @@
+"""
+Example 1 — train (or fine-tune) OQAE on a local AnnData of raw counts.
+
+This is the "bring-your-own-data" path: point the loader at a local
+``.h5ad`` / ``.zarr`` of **raw counts**, derive the organism's
+:class:`~omvqvae.data.dataset.GeneVocabulary` from the file's own genes, train an
+:class:`~omvqvae.models.vqvae.OmicsVQVAE` with the source-agnostic
+:func:`omvqvae.train.train` loop, and save a Hub-ready model directory with
+:func:`omvqvae.hf_utils.save_pretrained`.
+
+The dataset here is tiny synthetic counts (see ``synthetic_data.py``) so the
+example runs offline in seconds; replace :func:`make_synthetic_anndata` with
+``omvqvae.data.load_anndata("your_cells.h5ad")`` for real data. The same run is
+also expressible as a one-liner with the ``oqae-train`` CLI::
+
+    oqae-train configs/train_toy.yaml -s data.path=your_cells.h5ad
+
+Run::
+
+    python examples/01_train_local_anndata.py
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+from synthetic_data import make_synthetic_anndata
+
+from omvqvae.data import GeneVocabulary, build_anndata_dataloader, extract_counts
+from omvqvae.hf_utils import save_pretrained
+from omvqvae.models import OmicsVQVAE
+from omvqvae.train import TrainConfig, train
+
+
+def main(save_directory: Optional[Path] = None) -> Path:
+    """
+    Train a small OQAE model on synthetic counts and save it.
+
+    Parameters
+    ----------
+    save_directory : pathlib.Path, optional
+        Where to write the Hub-ready model directory. A temporary directory is
+        used when omitted.
+
+    Returns
+    -------
+    pathlib.Path
+        The directory the trained model was saved to (``config.json`` +
+        ``pytorch_model.bin``).
+    """
+    organism = "homo_sapiens"
+
+    # 1. Get raw counts. Swap this for `omvqvae.data.load_anndata(path)`.
+    adata = make_synthetic_anndata(n_cells=256, n_genes=40, organism=organism)
+
+    # 2. The reference gene space is the organism's vocabulary. For a local file
+    #    we derive it from the file's own genes; a Census run would read it from
+    #    the Census `var` index instead.
+    _, gene_ids = extract_counts(adata)
+    vocabulary = GeneVocabulary(organism, gene_ids)
+    print(f"Vocabulary: {organism} with {vocabulary.n_genes} genes")
+
+    # 3. Build a DataLoader of `Minibatch`es (raw counts + size factors). This is
+    #    the *same* contract the Census streaming loader yields.
+    loader = build_anndata_dataloader(
+        adata,
+        vocabulary,
+        batch_size=64,
+        shuffle=True,
+        batch_key="batch",
+    )
+
+    # 4. Model: raw counts -> encoder -> residual VQ -> decoder -> NB likelihood.
+    model = OmicsVQVAE(
+        n_genes=vocabulary.n_genes,
+        n_latent=16,
+        hidden_dims=(64,),
+        likelihood="nb",
+        codebook_size=64,
+        n_codebooks=2,
+    )
+
+    # 5. Train. The loop is source-agnostic and logs through a console tracker by
+    #    default (set up a W&B tracker for real runs).
+    result = train(model, loader, config=TrainConfig(max_epochs=8, lr=1e-3))
+    last = result.last_epoch
+    assert last is not None
+    print(
+        f"Trained {result.global_step} steps | "
+        f"final loss={last.loss:.4g} recon={last.reconstruction_loss:.4g} "
+        f"vq={last.vq_loss:.4g} perplexity={last.perplexity:.4g}"
+    )
+
+    # 6. Save a Hub-ready directory (weights + architecture + gene vocabulary).
+    #    `omvqvae.hf_utils.push_to_hub(model, vocabulary, "user/oqae-human")`
+    #    would upload the same artifacts to the HuggingFace Hub.
+    if save_directory is None:
+        save_directory = Path(tempfile.mkdtemp(prefix="oqae_example_")) / "model"
+    out = save_pretrained(model, vocabulary, save_directory)
+    print(f"Saved model to {out}")
+    return out
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/02_inspect_and_generate_codes.py
+++ b/examples/02_inspect_and_generate_codes.py
@@ -1,0 +1,117 @@
+"""
+Example 2 — encode cells to discrete codes, inspect them, decode / generate.
+
+This walks the user-facing latent API (:mod:`omvqvae.inference`) on a trained
+model:
+
+- **encode**: raw counts -> an :class:`~omvqvae.inference.EncodedCells` bundle
+  (per-cell ``codes`` ``(n_cells, n_codebooks)`` + ``size_factors`` + the
+  continuous ``latent``). ``encode_anndata`` first aligns a local AnnData to the
+  model's gene vocabulary.
+- **inspect**: each cell is now a tiny integer code; cells sharing a latent
+  program should share codes, and the codebook should be well utilized.
+- **decode**: codes (+ size factor) -> expected counts, i.e. a generative
+  reconstruction. ``decode_to_params`` exposes the full likelihood parameters.
+- **generate**: feed *hand-edited* codes back through the decoder to synthesize a
+  novel expression profile from the shared discrete vocabulary.
+
+Runs offline in seconds on synthetic data. Run::
+
+    python examples/02_inspect_and_generate_codes.py
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+import torch
+from synthetic_data import make_synthetic_anndata
+
+from omvqvae.data import GeneVocabulary, build_anndata_dataloader, extract_counts
+from omvqvae.hf_utils import load_pretrained, save_pretrained
+from omvqvae.inference import decode, decode_to_params, encode_anndata
+from omvqvae.models import OmicsVQVAE
+from omvqvae.train import TrainConfig, train
+
+
+def _train_tiny_model(adata: object, vocabulary: GeneVocabulary) -> OmicsVQVAE:
+    """Train a small model so the example has codes to inspect."""
+    loader = build_anndata_dataloader(adata, vocabulary, batch_size=64, shuffle=True)
+    model = OmicsVQVAE(
+        n_genes=vocabulary.n_genes,
+        n_latent=16,
+        hidden_dims=(64,),
+        likelihood="nb",
+        codebook_size=64,
+        n_codebooks=2,
+    )
+    train(model, loader, config=TrainConfig(max_epochs=10, lr=1e-3))
+    return model
+
+
+def main(workdir: Optional[Path] = None) -> None:
+    """Train a tiny model, then encode / inspect / decode / generate."""
+    organism = "homo_sapiens"
+    adata = make_synthetic_anndata(n_cells=256, n_genes=40, organism=organism)
+    _, gene_ids = extract_counts(adata)
+    vocabulary = GeneVocabulary(organism, gene_ids)
+
+    # Train then round-trip through a saved directory so we get a `LoadedModel`
+    # (model + vocabulary) — exactly what `from_pretrained` returns from the Hub.
+    model = _train_tiny_model(adata, vocabulary)
+    if workdir is None:
+        workdir = Path(tempfile.mkdtemp(prefix="oqae_example_"))
+    save_pretrained(model, vocabulary, workdir / "model")
+    loaded = load_pretrained(workdir / "model")
+
+    # --- Encode: cells -> discrete codes -------------------------------------
+    # `encode_anndata` aligns the AnnData to the model's gene vocabulary first
+    # (missing genes zero-filled, extra genes dropped), so it is robust to gene
+    # ordering. For an already-aligned matrix use `encode(model, counts)`.
+    encoded = encode_anndata(loaded, adata)
+    print(f"Encoded {len(encoded)} cells")
+    print(f"  codes shape       : {tuple(encoded.codes.shape)}  (n_cells, n_codebooks)")
+    print(f"  size_factors shape: {tuple(encoded.size_factors.shape)}")
+    print(f"  example codes     : {encoded.codes[:3].tolist()}")
+
+    # --- Inspect: utilization + program structure ----------------------------
+    n_unique = torch.unique(encoded.codes, dim=0).shape[0]
+    used_level0 = int(torch.unique(encoded.codes[:, 0]).numel())
+    print(
+        f"  {n_unique} distinct codes across {len(encoded)} cells; "
+        f"{used_level0} codebook entries used at level 0"
+    )
+    programs = np.asarray(adata.obs["program"])
+    for program in np.unique(programs):
+        rows = encoded.codes[programs == program]
+        majority = torch.mode(rows[:, 0]).values.item()
+        share = float((rows[:, 0] == majority).float().mean())
+        print(f"  {program}: {share:.0%} share the same level-0 code ({majority})")
+
+    # --- Decode: codes -> expected counts (generative reconstruction) --------
+    reconstructed = decode(loaded.model, encoded)
+    observed = torch.from_numpy(adata.X.astype(np.float32))
+    corr = float(
+        torch.corrcoef(torch.stack([observed.flatten(), reconstructed.flatten()]))[0, 1]
+    )
+    print(f"Reconstruction: counts shape {tuple(reconstructed.shape)}, corr={corr:.3f}")
+
+    # `decode_to_params` exposes the full NB distribution (mean rate, dispersion)
+    # for sampling or inspection rather than just the mean.
+    params = decode_to_params(loaded.model, encoded)
+    print(f"Likelihood params: {{{', '.join(params)}}}")
+
+    # --- Generate: edit codes, decode a novel profile ------------------------
+    # The codes are a composable vocabulary: change a level and decode to
+    # synthesize a profile that need not correspond to any observed cell.
+    novel = encoded.codes[:1].clone()
+    novel[0, 0] = (novel[0, 0] + 1) % loaded.model.codebook_size
+    generated = decode(loaded.model, novel, size_factors=encoded.size_factors[:1])
+    print(f"Generated 1 synthetic profile from edited codes: {tuple(generated.shape)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/03_census_streaming.py
+++ b/examples/03_census_streaming.py
@@ -1,0 +1,86 @@
+"""
+Example 3 — train OQAE by streaming from the CZ CELLxGENE Census.
+
+This is the at-scale path: instead of holding data in memory, stream raw counts
+straight from the Census via TileDB-SOMA. An ``obs_value_filter`` selects the
+slice of cells (here a small tissue/assay subset so the example stays light), the
+per-organism :class:`~omvqvae.data.dataset.GeneVocabulary` is read from the
+Census ``var`` index, and the resulting loader yields the *same*
+:class:`~omvqvae.data.dataset.Minibatch` contract as the local-AnnData loader —
+so the model and training loop are identical to example 1.
+
+.. note::
+
+   **This example requires network access** to the CELLxGENE Census and is
+   therefore *not* run in CI (the offline examples 1 and 2 cover the API). It is
+   written to be runnable manually::
+
+       python examples/03_census_streaming.py
+
+   For a heavier run, drop the ``obs_value_filter`` / raise ``max_steps`` and add
+   a W&B tracker. The Census version is pinned for reproducibility.
+"""
+
+from __future__ import annotations
+
+from omvqvae.data import (
+    DEFAULT_CENSUS_VERSION,
+    build_census_dataloader,
+    census_gene_vocabulary,
+    open_census,
+)
+from omvqvae.models import OmicsVQVAE
+from omvqvae.train import TrainConfig, train
+
+
+def main() -> None:  # pragma: no cover - requires live Census/TileDB-SOMA
+    """Stream a small human Census slice and train a few steps on it."""
+    organism = "homo_sapiens"
+
+    # A narrow slice keeps the example light; widen the filter for real training.
+    obs_value_filter = (
+        "tissue_general == 'blood' and is_primary_data == True "
+        "and assay == '10x 3\\' v3'"
+    )
+
+    with open_census(census_version=DEFAULT_CENSUS_VERSION) as census:
+        # The reference gene space is the Census `var` index for the organism.
+        vocabulary = census_gene_vocabulary(census, organism)
+        print(f"Census {DEFAULT_CENSUS_VERSION}: {vocabulary.n_genes} {organism} genes")
+
+        # Streaming loader of `Minibatch`es — identical contract to example 1.
+        loader = build_census_dataloader(
+            census,
+            organism,
+            vocabulary,
+            obs_value_filter=obs_value_filter,
+            batch_size=128,
+            shuffle=True,
+            seed=0,
+        )
+
+        model = OmicsVQVAE(
+            n_genes=vocabulary.n_genes,
+            n_latent=32,
+            hidden_dims=(256, 128),
+            likelihood="nb",
+            codebook_size=512,
+            n_codebooks=2,
+        )
+
+        # `max_steps` caps the smoke run; the loader stays open for the duration.
+        result = train(
+            model,
+            loader,
+            config=TrainConfig(max_epochs=1, max_steps=20, lr=1e-3),
+        )
+        last = result.last_epoch
+        assert last is not None
+        print(
+            f"Streamed {result.global_step} steps | "
+            f"loss={last.loss:.4g} perplexity={last.perplexity:.4g}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,55 @@
+# OQAE examples
+
+Runnable, self-contained scripts demonstrating the OQAE API end to end. Examples
+1 and 2 run **offline in seconds** on tiny synthetic counts (see
+[`synthetic_data.py`](synthetic_data.py)); example 3 streams from the CZ
+CELLxGENE Census and needs network access.
+
+| # | Script | What it shows | Offline |
+|---|--------|---------------|:-------:|
+| 1 | [`01_train_local_anndata.py`](01_train_local_anndata.py) | Train / fine-tune on a local `.h5ad` / `.zarr` of raw counts, then save a Hub-ready model directory. | ✅ |
+| 2 | [`02_inspect_and_generate_codes.py`](02_inspect_and_generate_codes.py) | Encode cells to discrete codes, inspect codebook usage, decode codes back to expression, and generate a novel profile from edited codes. | ✅ |
+| 3 | [`03_census_streaming.py`](03_census_streaming.py) | Train at scale by streaming a Census slice via TileDB-SOMA (same `Minibatch` contract as example 1). | ❌ (network) |
+
+## Running
+
+From the repository root, with the dev environment set up (`make setup-env`):
+
+```bash
+uv run python examples/01_train_local_anndata.py
+uv run python examples/02_inspect_and_generate_codes.py
+uv run python examples/03_census_streaming.py   # requires network (Census)
+```
+
+Each script exposes a `main()` function, so it can also be imported and driven
+programmatically. The offline examples are smoke-tested in
+[`tests/test_examples.py`](../tests/test_examples.py).
+
+## Using your own data
+
+- **Local file** (example 1): replace `make_synthetic_anndata(...)` with
+  `omvqvae.data.load_anndata("your_cells.h5ad")`. Counts must be **raw** (the
+  model normalizes internally). The same run is a one-liner via the CLI:
+
+  ```bash
+  oqae-train configs/train_toy.yaml -s data.path=your_cells.h5ad
+  ```
+
+- **Census** (example 3): widen the `obs_value_filter`, raise `max_steps`, and
+  wire a Weights & Biases tracker for monitoring.
+
+## API at a glance
+
+```text
+raw counts ──encode──► codes (n_cells, n_codebooks) ──decode──► expected counts
+   (.h5ad / Census)     + per-cell size factor          (generative decoder)
+```
+
+- `omvqvae.data` — `GeneVocabulary`, `build_anndata_dataloader`,
+  `build_census_dataloader` (organism-aware loaders → `Minibatch`).
+- `omvqvae.models.OmicsVQVAE` — encoder → residual VQ → NB/ZINB/Gaussian decoder.
+- `omvqvae.train.train` — source-agnostic training loop (console or W&B tracking).
+- `omvqvae.inference` — `encode` / `encode_anndata` / `decode` /
+  `decode_to_params` (the discrete-code latent API).
+- `omvqvae.hf_utils` — `save_pretrained` / `load_pretrained` / `push_to_hub` /
+  `from_pretrained` (Hub-ready serialization).

--- a/examples/synthetic_data.py
+++ b/examples/synthetic_data.py
@@ -1,0 +1,90 @@
+"""
+Tiny synthetic single-cell data for the OQAE examples.
+
+The examples are meant to run **offline in seconds** — they illustrate the OQAE
+API rather than train a useful model — so they all share this helper instead of
+downloading anything. It fabricates a small raw-count
+:class:`anndata.AnnData` with a handful of latent "cell programs", which gives
+the residual VQ a little structure to quantize while staying tiny.
+
+Run any example directly, e.g.::
+
+    python examples/01_train_local_anndata.py
+
+For the real thing, swap this for a local ``.h5ad`` / ``.zarr`` of raw counts
+(example 1) or stream from the CELLxGENE Census (example 3).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List
+
+import numpy as np
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from anndata import AnnData
+
+
+def synthetic_gene_ids(n_genes: int, organism: str = "homo_sapiens") -> List[str]:
+    """Return ``n_genes`` ordered, organism-flavoured gene identifiers."""
+    prefix = "ENSMUSG" if organism == "mus_musculus" else "ENSG"
+    return [f"{prefix}{i:05d}" for i in range(n_genes)]
+
+
+def make_synthetic_anndata(
+    *,
+    n_cells: int = 256,
+    n_genes: int = 40,
+    n_programs: int = 4,
+    organism: str = "homo_sapiens",
+    seed: int = 0,
+) -> "AnnData":
+    """
+    Build a small synthetic raw-count AnnData with latent structure.
+
+    Each cell is assigned one of ``n_programs`` "programs"; a program is a random
+    per-gene rate vector, and counts are Poisson draws from that rate scaled by a
+    per-cell sequencing depth. The program id is stored in ``obs["program"]`` so
+    examples can sanity-check that similar cells receive similar discrete codes.
+
+    Parameters
+    ----------
+    n_cells : int, default 256
+        Number of cells (rows).
+    n_genes : int, default 40
+        Number of genes (columns).
+    n_programs : int, default 4
+        Number of latent expression programs.
+    organism : str, default "homo_sapiens"
+        Selects the gene-id prefix (``"homo_sapiens"`` / ``"mus_musculus"``).
+    seed : int, default 0
+        RNG seed for reproducibility.
+
+    Returns
+    -------
+    anndata.AnnData
+        Cells x genes raw counts in ``X`` with ``obs["program"]`` /
+        ``obs["batch"]`` and gene ids as ``var_names``.
+    """
+    import pandas as pd
+    from anndata import AnnData  # lazy import keeps `import` cheap
+
+    rng = np.random.default_rng(seed)
+    # One random non-negative rate vector per program.
+    program_rates = rng.gamma(shape=1.5, scale=1.0, size=(n_programs, n_genes))
+    programs = rng.integers(0, n_programs, size=n_cells)
+    depths = rng.uniform(0.5, 2.0, size=n_cells)
+
+    rates = program_rates[programs] * depths[:, None]
+    counts = rng.poisson(rates).astype(np.float32)
+
+    gene_ids = synthetic_gene_ids(n_genes, organism)
+    obs = pd.DataFrame(
+        {
+            "program": [f"program_{p}" for p in programs],
+            "batch": [f"batch_{i % 2}" for i in range(n_cells)],
+        },
+        index=[f"cell_{i}" for i in range(n_cells)],
+    )
+    var = pd.DataFrame(index=gene_ids)
+    return AnnData(X=counts, obs=obs, var=var)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,76 @@
+"""
+Smoke tests for the runnable examples under ``examples/``.
+
+The offline examples (1 and 2) are executed end to end on tiny synthetic data so
+the documented workflows are guaranteed to keep working; the Census example (3)
+needs network access, so it is only *imported* here (to catch syntax / import
+regressions) and its ``main`` is exercised under the ``network`` marker.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+EXAMPLES_DIR = Path(__file__).resolve().parent.parent / "examples"
+
+
+def _load_example(filename: str) -> ModuleType:
+    """Import an example script by file path (handles digit-prefixed names)."""
+    # Examples import their sibling ``synthetic_data`` helper by bare name, which
+    # works when run directly (script dir on ``sys.path``); replicate that here.
+    if str(EXAMPLES_DIR) not in sys.path:
+        sys.path.insert(0, str(EXAMPLES_DIR))
+    module_name = f"oqae_example_{Path(filename).stem}"
+    spec = importlib.util.spec_from_file_location(module_name, EXAMPLES_DIR / filename)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_synthetic_data_has_structure() -> None:
+    """The shared helper builds a tiny raw-count AnnData with program labels."""
+    module = _load_example("synthetic_data.py")
+    adata = module.make_synthetic_anndata(n_cells=32, n_genes=10, n_programs=3)
+    assert adata.shape == (32, 10)
+    assert (adata.X >= 0).all()
+    assert "program" in adata.obs
+    assert len(module.synthetic_gene_ids(5, "mus_musculus")) == 5
+
+
+def test_example_01_trains_and_saves(tmp_path: Path) -> None:
+    """Example 1 trains a model and writes a loadable Hub-ready directory."""
+    from omvqvae.hf_utils import load_pretrained
+
+    module = _load_example("01_train_local_anndata.py")
+    out = module.main(save_directory=tmp_path / "model")
+
+    assert (out / "config.json").exists()
+    assert (out / "pytorch_model.bin").exists()
+    loaded = load_pretrained(out)
+    assert loaded.model.n_genes == loaded.vocabulary.n_genes
+
+
+def test_example_02_inspects_and_generates(tmp_path: Path) -> None:
+    """Example 2 runs the encode / inspect / decode / generate workflow."""
+    module = _load_example("02_inspect_and_generate_codes.py")
+    # Runs end to end without raising; exercises the full inference API.
+    module.main(workdir=tmp_path)
+
+
+def test_example_03_imports() -> None:
+    """The Census example imports cleanly (its ``main`` is network-gated)."""
+    module = _load_example("03_census_streaming.py")
+    assert callable(module.main)
+
+
+@pytest.mark.network
+def test_example_03_streams() -> None:  # pragma: no cover - requires live Census
+    """Run the Census streaming example end to end (skipped by default)."""
+    module = _load_example("03_census_streaming.py")
+    module.main()


### PR DESCRIPTION
## Description
First slice of PR #8 (Examples & Documentation): a set of runnable, offline-by-default example scripts that demonstrate the OQAE API end to end. The Sphinx docs scaffold is deferred to slice 2 (next run) to keep this PR-sized.

## Type of change
- [x] Documentation update
- [x] New feature (examples + smoke tests; no library code changed)
- [x] Test improvements

## Implementation
### Changes made:
- `examples/synthetic_data.py` — shared helper building a tiny raw-count `AnnData` with latent "programs" (offline, seconds).
- `examples/01_train_local_anndata.py` — bring-your-own-data path: derive a `GeneVocabulary` from a local AnnData, train an `OmicsVQVAE` with `omvqvae.train.train`, and `save_pretrained` a Hub-ready directory.
- `examples/02_inspect_and_generate_codes.py` — the full `omvqvae.inference` walk: `save_pretrained`/`load_pretrained` → `encode_anndata` → inspect codebook usage / per-program code structure → `decode` (generative reconstruction) → `decode_to_params` → generate a novel profile from hand-edited codes.
- `examples/03_census_streaming.py` — train-at-scale path: stream a Census slice via TileDB-SOMA (same `Minibatch` contract as example 1). Network-gated.
- `examples/README.md` — overview table, run instructions, and an API-at-a-glance.
- `tests/test_examples.py` — smoke-tests the offline examples end to end (importlib-driven `main()` on tiny data); imports the Census example to catch regressions, with its `main` exercised only under `@pytest.mark.network`.
- `docs/STATUS.md`, `docs/PROJECT_PLAN.md` — moved PR #8 slice 1 to the changelog, set the new Next task (slice 2: Sphinx docs), and logged the design decision.

### Architecture decisions:
- **Plain `.py` scripts, not notebooks.** Scripts are diffable, lint/format-clean, and runnable in CI without an `nbconvert`/`jupyter` execution layer, so the documented workflows are guaranteed to keep working. A shared synthetic helper keeps them tiny and offline.
- **Slice PR #8** into scripts-first (this PR) and Sphinx-docs-second, keeping each run to one CI-verifiable chunk.

## Testing
- [x] Tests added/updated
- [x] All tests pass locally (`make ci` green: black/isort/flake8/mypy strict/pytest)
- [x] Test coverage maintained/improved
- [x] Manual testing completed (ran examples 1 & 2 directly)

### Test coverage:
- Current coverage: ~99.7%
- Coverage change: no change — examples live under `examples/` (outside the `src` coverage scope), so the gate is unaffected; the smoke tests still exercise `src` via the public API.

## Code Quality
- [x] Code follows project style guidelines
- [x] Self-review of the code completed
- [x] Code is self-documenting or includes comments
- [x] No new linter warnings
- [x] Type hints added for new code

## Documentation
- [x] Documentation updated (`docs/STATUS.md`, `docs/PROJECT_PLAN.md`)
- [x] README updated (`examples/README.md`)
- [ ] API documentation updated — Sphinx scaffold is slice 2

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DSBJKPT5fbRiCvjoRwGZNd)_