### PR TITLE
docs(sphinx): Sphinx documentation scaffold (PR #8 slice 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,27 @@ jobs:
         name: codecov-umbrella
         fail_ci_if_error: false
 
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v4
+      with:
+        version: "latest"
+
+    - name: Set up Python
+      run: uv python install 3.11
+
+    - name: Install dependencies
+      run: |
+        uv sync --all-extras
+
+    - name: Build docs (warnings as errors)
+      run: |
+        uv run sphinx-build -b html -W --keep-going docs/source docs/_build/html
+
   security:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install install-dev test lint format type-check clean setup-env
+.PHONY: help install install-dev test lint format type-check clean setup-env docs docs-clean
 
 # Default target
 help:
@@ -19,6 +19,10 @@ help:
 	@echo "  type-check    - Run type checking (mypy strict)"
 	@echo "  pre-commit    - Run pre-commit hooks"
 	@echo "  ci            - Run full CI pipeline locally (matches GitHub)"
+	@echo ""
+	@echo "📚 Documentation:"
+	@echo "  docs          - Build Sphinx HTML docs (warnings-as-errors)"
+	@echo "  docs-clean    - Remove built docs (docs/_build/)"
 	@echo ""
 	@echo "🔄 Workflow Management:"
 	@echo "  issue              - Create new GitHub issue"
@@ -81,6 +85,15 @@ type-check:
 
 pre-commit:
 	uv run pre-commit run --all-files
+
+# Documentation
+docs:
+	@echo "📚 Building Sphinx documentation..."
+	uv run --extra docs sphinx-build -b html -W --keep-going docs/source docs/_build/html
+	@echo "✅ Docs built at docs/_build/html/index.html"
+
+docs-clean:
+	rm -rf docs/_build/
 
 # Cleaning
 clean:

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -327,17 +327,21 @@ src/omvqvae/
   documented code-vector format (see `inference/codes.py` module docstring); 100%
   offline coverage on the module; `make ci` green.
 
-#### **PR #8: Examples & Documentation — 🚧 IN PROGRESS (slice 1 done)**
+#### **PR #8: Examples & Documentation — ✅ DONE**
 - **Scope**: examples (Census streaming, local fine-tuning, code
   inspection/generation), Sphinx docs.
-- **Status**: *Slice 1* (example scripts) **DONE** — `examples/` holds three
+- **Status**: complete. *Slice 1* (example scripts) — `examples/` holds three
   runnable scripts (`01_train_local_anndata.py`,
   `02_inspect_and_generate_codes.py`, `03_census_streaming.py`), a `README.md`,
   and a shared offline `synthetic_data.py` helper; offline examples are
-  smoke-tested in `tests/test_examples.py`. *Slice 2* (Sphinx docs scaffold +
-  autodoc of the public API) is next.
-- **Exit criteria**: docs build; examples run on small data. Examples met
-  (offline, CI-tested); the docs build is slice 2.
+  smoke-tested in `tests/test_examples.py`. *Slice 2* (Sphinx docs) — a Sphinx
+  project under `docs/source/` (`autodoc` + `napoleon` over the NumPy
+  docstrings, `furo` theme): `index.rst`, a narrative `getting_started.rst`
+  linking the examples, and `api.rst` autodoccing the public API by module. A
+  `make docs` target (`sphinx-build -W`) and a `docs` CI job keep the build
+  warning-clean; added a `docs` extra (`sphinx`, `furo`) + refreshed `uv.lock`.
+- **Exit criteria** (met): docs build clean (warnings-as-errors); examples run
+  on small data (offline, CI-tested).
 
 #### **PR #9: Benchmarking & Scaling**
 - **Scope**: raw-count+NB vs log-normalized+Gaussian comparison; codebook
@@ -433,6 +437,7 @@ A running record of decisions so future sessions don't re-litigate them.
 | 2026-06-25 | **HF serialization = self-describing model + a HuggingFace-style directory.** Added `OmicsVQVAE.get_config()` / `from_config()` (the model carries every constructor hyper-parameter), so `hf_utils.save_pretrained` writes `config.json` (`{format_version, organism, gene_ids, model=get_config(), experiment_config}`) + `pytorch_model.bin` and `load_pretrained` rebuilds the exact model/feature space — decoupled from the training CLI. `hf_utils.py` lives at the **package top level** (per the package-structure diagram, not under `models/` or `inference/`). `from_checkpoint` converts a CLI `{state_dict, organism, gene_ids, config}` bundle into the same directory shape so both share one format; `push_to_hub` / `from_pretrained` are thin `huggingface_hub` shells (`# pragma: no cover`, network-gated) wrapping the tested pure save/load step. Added direct dep `huggingface-hub>=0.20.0` (already transitive via `transformers`). | Making the model self-describing is the standard HF `PreTrainedModel` pattern and keeps serialization independent of `train.cli`/OmegaConf. A plain JSON+weights directory *is* a Hub-ready repo and is fully offline-testable, leaving only upload/download as the networked edge. Reusing the CLI bundle's architecture fields via `from_checkpoint` avoids two divergent on-disk formats. |
 | 2026-06-26 | **Discrete-code inference API = free functions over a trained model returning an `EncodedCells` bundle, with the code→vector inverse path pushed into the layer/model.** `inference/codes.py` exposes `encode`/`encode_anndata` (→ `EncodedCells{codes (n_cells, n_codebooks) int64, size_factors, latent}`) and `decode`/`decode_to_params`. The codes alone don't reconstruct depth — decoding needs a per-cell `size_factor`, so `encode` returns it in the bundle and `decode` reuses it (overridable). The inverse `indices → summed quantized vector` is a tested `ResidualVQ.lookup` / `OmicsVQVAE.decode_codes` method rather than reaching into codebook buffers. All inference forces `eval` + `no_grad` (so EMA/dead-code stats aren't mutated) and restores the prior mode; `encode`/`decode` are batched. `encode_anndata` takes a `LoadedModel` and aligns via `align_to_reference` (annotation under `TYPE_CHECKING` to avoid an import cycle / heavy import). | Free functions keep the API thin and match the functional style of the data/train layers; the `EncodedCells` bundle makes the codes+size-factor pair (the actual compressed representation) explicit and gives a frictionless `decode(model, encode(model, x))` round-trip. Putting `lookup`/`decode_codes` on the layer/model keeps inference decoupled from quantizer internals and is reusable by generation/benchmarking PRs. Forcing eval/no_grad prevents inference from silently drifting the codebooks. |
 | 2026-06-27 | **Examples = standalone runnable scripts under `examples/` (not notebooks), smoke-tested offline.** Three scripts share one synthetic-data helper (`synthetic_data.py`): local-AnnData training+`save_pretrained` (1), the full `omvqvae.inference` encode→inspect→decode→generate walk via a `save_pretrained`/`load_pretrained` round-trip (2), and Census streaming (3, network-gated). Each exposes a `main()`; `tests/test_examples.py` imports them via `importlib` and runs the offline ones end to end (example 3's `main` only under `@pytest.mark.network`). Examples live outside the `src` coverage scope, so they don't move the coverage gate. Split PR #8 into slices: scripts first (this PR), Sphinx docs second. | Plain `.py` scripts are diffable, lint/format-clean, and — unlike notebooks — runnable in CI with no `nbconvert`/`jupyter` execution layer, so the documented workflows are guaranteed to keep working. A shared synthetic helper keeps them tiny and offline. Reusing `save_pretrained`/`load_pretrained` in example 2 also exercises the HF round-trip the way a real user would (`from_pretrained` → `LoadedModel` → `encode_anndata`). Slicing keeps each run to one CI-verifiable chunk; the Sphinx scaffold needs new docs deps + a build target and slots in next. |
+| 2026-06-28 | **Docs = a Sphinx `autodoc` + `napoleon` project under `docs/source/`, built warnings-as-errors and CI-gated.** `api.rst` autodocs the *implementation* modules (e.g. `omvqvae.data.dataset`, not the re-exporting `omvqvae.data` `__init__`) since autodoc skips imported members by default; `getting_started.rst` links the `examples/` scripts on GitHub rather than `literalinclude`-ing them. Build output goes to `docs/_build/` (already gitignored). Added a `docs` extra (`sphinx>=7`, `furo`) and a `make docs` target; added a dedicated **`docs` CI job** (`sphinx-build -W`) rather than deferring it to PR #10. Markdown code fences in two module docstrings were converted to RST literal blocks to keep the build warning-clean. | Reusing the already-written NumPy docstrings via autodoc keeps one source of truth for the API and makes drift a CI failure. Documenting implementation modules (not the package `__init__`) is what surfaces the actual classes/functions. Building warnings-as-errors in CI now (cheap, one job) prevents docstring rot accumulating until the release PR. `furo` is a low-config, modern theme with no extra build steps. |
 | 2026-06-24 | **Training CLI = OmegaConf structured config + a single-command typer app (`oqae-train`).** The config schema is plain dataclasses (`ExperimentConfig`/`ModelConfig`/`DataConfig`/`TrainingConfig`/`TrackingConfig`) so OmegaConf validates the YAML, rejects unknown keys, and supports `--set a.b=c` dot-list overrides; `OmegaConf.to_object` yields typed objects for mypy. Pure builders (`build_model`/`build_train_config`/`build_tracker_from_config`/`build_data`) map one config section → one object and `run_experiment` wires them, so the config→objects path is unit-tested offline. The **local-AnnData** source derives its `GeneVocabulary` (hence the model's `n_genes`) from the file's own genes; the **Census** source is the one networked branch (`# pragma: no cover`). The optional checkpoint stores `{state_dict, organism, gene_ids, config}`. | A declarative, schema-checked config keeps runs reproducible and overridable from the shell; the pure-builder split keeps the heavy/networked I/O at the edges and everything else offline-testable (incl. via Typer's `CliRunner`). Persisting `gene_ids`/`organism`/`config` alongside the weights is what PR #6 (HF Hub) and PR #7 (inference) need to reload a model against the right feature space. Single-command typer means `oqae-train config.yaml` with no redundant subcommand name. |
 
 ## 🔄 **Future Roadmap (Post-v1.0)**
@@ -450,11 +455,11 @@ A running record of decisions so future sessions don't re-litigate them.
 
 ---
 
-**Last Updated**: 2026-06-27 — PR #8 slice 1 complete: `examples/` holds three
-runnable scripts (local-AnnData training, the encode→inspect→decode→generate
-inference walk, and Census streaming) over a shared offline synthetic-data
-helper, smoke-tested in `tests/test_examples.py`.
-**Current Focus**: PR #8 slice 2 — Sphinx docs scaffold (autodoc the public API:
-`data`, `layers`, `models`, `train`, `inference`, `hf_utils`,
-`utils.tracking`; getting-started page linking the examples); see `docs/STATUS.md`.
-**Next Review**: After PR #8 slice 2 (Sphinx documentation).
+**Last Updated**: 2026-06-28 — PR #8 complete: Sphinx docs (slice 2) added under
+`docs/source/` (autodoc + napoleon over the public API, a narrative
+getting-started page linking the `examples/` scripts, `furo` theme), with a
+`make docs` target and a `docs` CI job building warnings-as-errors.
+**Current Focus**: PR #9 — benchmarking & scaling (raw-count+NB vs
+log-normalized+Gaussian, codebook config sweeps, streaming throughput); see
+`docs/STATUS.md`.
+**Next Review**: After PR #9 (benchmarking & scaling).

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -4,7 +4,7 @@
 > end of every working session** so the next session can pick up cold. Keep it
 > short; deep rationale lives in `docs/PROJECT_PLAN.md`.
 
-**Last updated:** 2026-06-27
+**Last updated:** 2026-06-28
 
 ## Current state
 
@@ -170,29 +170,56 @@
     Examples live under `examples/` (outside the `src` coverage scope), so they
     don't affect the coverage gate; `make ci` green (~99.7%). No new deps.
 
-## Next task — PR #8 slice 2: Sphinx documentation
+- **PR #8 slice 2 (Sphinx documentation) — DONE (this PR). PR #8 complete.**
+  - `docs/source/` — a Sphinx project (`conf.py` with `autodoc` + `napoleon`
+    for the NumPy docstrings, `viewcode`, `intersphinx`; `furo` theme). `index.rst`
+    is the landing page (project overview + highlights + toctree);
+    `getting_started.rst` is a narrative walk-through (install → train local /
+    Census → encode/decode → save/share) linking the `examples/` scripts on
+    GitHub; `api.rst` autodocs the full public API by implementation module
+    (`data.dataset`/`normalize`/`anndata_io`/`census`, `layers.residual_vq`,
+    `models.likelihoods`/`vqvae`, `train.loop`/`cli`, `inference.codes`,
+    `hf_utils`, `utils.tracking`).
+  - Wired a `make docs` (and `docs-clean`) target running `sphinx-build -W
+    --keep-going` (warnings-as-errors) into `docs/_build/html` (already
+    gitignored). Added a `docs` extra (`sphinx>=7`, `furo`) and refreshed
+    `uv.lock`. Added a **`docs` CI job** that builds the docs warnings-as-errors
+    so they stay buildable (the optional CI-docs decision — done now rather than
+    deferred to PR #10).
+  - Fixed two module docstrings (`models/vqvae.py`, `inference/codes.py`) whose
+    Markdown ```` ``` ```` code fences aren't valid reStructuredText → converted
+    to RST `.. code-block:: text` literal blocks so the build is warning-clean.
+    `make ci` green (~99.7%); `make docs` clean.
 
-PR #8 slice 1 (example scripts) is **DONE**. Next is slice 2 — the Sphinx docs
-scaffold:
+## Next task — PR #9: Benchmarking & Scaling
 
-1. Add a Sphinx project under `docs/` (e.g. `docs/source/`) with `conf.py`
-   (autodoc + napoleon for the NumPy docstrings) and an index that autodocs the
-   public API: `data`, `layers`, `models`, `train`, `inference`, `hf_utils`,
-   `utils.tracking`.
-2. A short narrative/getting-started page linking the `examples/` scripts.
-3. Make `docs/` build (`sphinx-build` clean); wire a `make docs` target. Add the
-   docs deps (`sphinx`, a theme, e.g. `furo`/`sphinx-rtd-theme`) under a `docs`
-   extra and refresh `uv.lock` in the same PR.
+PR #8 is **complete** (examples + Sphinx docs). Next is **PR #9** (see
+`docs/PROJECT_PLAN.md` → Phase 3):
 
-**Definition of done:** `docs/` build clean; CI green; PR opened. Decide whether
-to also add a CI job that builds the docs (optional — can defer to PR #10).
+- **Scope**: raw-count+NB vs log-normalized+Gaussian comparison; codebook
+  config sweeps (`n_codebooks` / `codebook_size`); streaming throughput/scaling.
+- **Exit criteria**: a benchmark report covering reconstruction quality,
+  codebook utilization (perplexity / no-collapse), downstream separability, and
+  streaming throughput.
+- This also resolves the parked **NB vs ZINB vs Gaussian** and **batch-effect
+  conditioning** open questions empirically (both were deferred to PR #9).
 
-### Available building blocks (for PR #8 slice 2)
+**Suggested first slice**: a small, offline-runnable benchmarking harness
+(`benchmarks/` or `src/omvqvae/benchmark/`) that trains tiny models under a few
+likelihood/codebook configs on synthetic data and emits a comparison table of
+reconstruction loss + codebook perplexity — establishing the metrics/reporting
+scaffold before wiring real Census-scale sweeps. Keep it offline-by-default with
+the live/large sweeps network-gated, matching the existing test discipline.
 
-- `examples/` — the runnable scripts to link from a getting-started page.
-- Public API to autodoc: `omvqvae.data`, `omvqvae.layers`, `omvqvae.models`,
-  `omvqvae.train`, `omvqvae.inference`, `omvqvae.hf_utils`,
-  `omvqvae.utils.tracking` (all NumPy-docstringed).
+### Available building blocks (for PR #9)
+
+- `omvqvae.train.train` / `TrainConfig` — the source-agnostic loop to run each
+  benchmark config; `vqvae_metrics` flattens a `VQVAEOutput` (losses + codebook
+  perplexity/usage) for reporting.
+- `OmicsVQVAE(likelihood=..., n_codebooks=..., codebook_size=...)` — the knobs
+  to sweep; `build_reconstruction_head` exposes `LIKELIHOODS`.
+- `examples/synthetic_data.py` — the offline raw-count AnnData fixture (latent
+  "programs") to benchmark reconstruction/separability against a known signal.
 
 ## Open questions / parked
 
@@ -211,6 +238,18 @@ to also add a CI job that builds the docs (optional — can defer to PR #10).
 
 ## Changelog (most recent first)
 
+- **2026-06-28** — PR #8 slice 2: Sphinx documentation. Added a Sphinx project
+  under `docs/source/` (`conf.py` with `autodoc` + `napoleon` for the NumPy
+  docstrings, `viewcode`, `intersphinx`, `furo` theme): `index.rst` (landing
+  page + toctree), `getting_started.rst` (narrative install → train → encode /
+  decode → save walk-through linking the `examples/` scripts), and `api.rst`
+  (autodoc of the full public API by implementation module). Wired `make docs` /
+  `docs-clean` (`sphinx-build -W --keep-going` → `docs/_build/html`) and a `docs`
+  CI job (warnings-as-errors). Added a `docs` extra (`sphinx>=7`, `furo`) and
+  refreshed `uv.lock`. Converted the Markdown code fences in two module
+  docstrings (`models/vqvae.py`, `inference/codes.py`) to RST literal blocks so
+  the build is warning-clean. `make ci` green (~99.7%); `make docs` clean. **PR
+  #8 is now complete.** Next is PR #9 (benchmarking & scaling).
 - **2026-06-27** — PR #8 slice 1: example scripts. Added `examples/` — three
   runnable, self-contained scripts (`01_train_local_anndata.py`,
   `02_inspect_and_generate_codes.py`, `03_census_streaming.py`), a `README.md`

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,0 +1,81 @@
+API reference
+=============
+
+Auto-generated reference for the public :mod:`omvqvae` API. Each section
+documents the implementation modules behind a subpackage; the subpackage
+``__init__`` re-exports these names (e.g. ``from omvqvae.data import
+GeneVocabulary``).
+
+Data layer (:mod:`omvqvae.data`)
+--------------------------------
+
+Organism-aware loading of raw single-cell counts onto a shared ``Minibatch``
+contract — local AnnData and CELLxGENE Census streaming, plus gene-space
+alignment and normalization.
+
+.. automodule:: omvqvae.data.dataset
+   :members:
+
+.. automodule:: omvqvae.data.normalize
+   :members:
+
+.. automodule:: omvqvae.data.anndata_io
+   :members:
+
+.. automodule:: omvqvae.data.census
+   :members:
+
+Layers (:mod:`omvqvae.layers`)
+------------------------------
+
+The residual vector-quantization bottleneck.
+
+.. automodule:: omvqvae.layers.residual_vq
+   :members:
+
+Models (:mod:`omvqvae.models`)
+------------------------------
+
+Reconstruction likelihoods / decoder heads and the end-to-end VQ-VAE.
+
+.. automodule:: omvqvae.models.likelihoods
+   :members:
+
+.. automodule:: omvqvae.models.vqvae
+   :members:
+
+Training (:mod:`omvqvae.train`)
+-------------------------------
+
+The source-agnostic training loop and the config-driven CLI.
+
+.. automodule:: omvqvae.train.loop
+   :members:
+
+.. automodule:: omvqvae.train.cli
+   :members:
+
+Inference (:mod:`omvqvae.inference`)
+------------------------------------
+
+The discrete-code latent API: encode expression into codes and decode codes
+back into expression.
+
+.. automodule:: omvqvae.inference.codes
+   :members:
+
+Serialization (:mod:`omvqvae.hf_utils`)
+---------------------------------------
+
+HuggingFace Hub-style model serialization.
+
+.. automodule:: omvqvae.hf_utils
+   :members:
+
+Experiment tracking (:mod:`omvqvae.utils.tracking`)
+---------------------------------------------------
+
+Offline-friendly experiment tracking (console / Weights & Biases).
+
+.. automodule:: omvqvae.utils.tracking
+   :members:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,79 @@
+"""Sphinx configuration for the OQAE documentation.
+
+Builds the HTML docs with autodoc + napoleon so the NumPy-style docstrings
+across the public ``omvqvae`` API are rendered automatically. The package is
+imported from the in-tree ``src/`` layout, so the docs always document the
+checked-out source.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# ``omvqvae`` lives under ``src/`` (src layout). Make it importable for autodoc
+# without requiring an editable install of the docs build environment.
+sys.path.insert(0, os.path.abspath("../../src"))
+
+# -- Project information -----------------------------------------------------
+
+project = "OQAE"
+author = "mengerj"
+project_copyright = "2026, mengerj"
+
+# Keep the documented version in lock-step with the package metadata.
+try:
+    from importlib.metadata import version as _pkg_version
+
+    release = _pkg_version("oqae")
+except Exception:  # pragma: no cover - fallback when not installed
+    release = "0.1.0"
+version = ".".join(release.split(".")[:2])
+
+# -- General configuration ---------------------------------------------------
+
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.intersphinx",
+]
+
+exclude_patterns: list[str] = []
+
+# -- Autodoc / Napoleon ------------------------------------------------------
+
+autodoc_default_options = {
+    "members": True,
+    "show-inheritance": True,
+    "member-order": "bysource",
+}
+# Move fully-annotated type hints out of the signature and into the parameter
+# descriptions so the rendered signatures stay readable.
+autodoc_typehints = "description"
+autodoc_class_signature = "separated"
+
+# Heavy / optional third-party deps are lazy-imported inside functions, but
+# mock the ones that can be slow or environment-specific to import so the docs
+# build stays fast and robust (e.g. on a docs-only CI runner).
+autodoc_mock_imports = [
+    "cellxgene_census",
+    "tiledbsoma",
+    "tiledbsoma_ml",
+]
+
+napoleon_numpy_docstring = True
+napoleon_google_docstring = False
+napoleon_use_rtype = True
+napoleon_use_param = True
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
+    "torch": ("https://pytorch.org/docs/stable/", None),
+}
+
+# -- HTML output -------------------------------------------------------------
+
+html_theme = "furo"
+html_title = "OQAE — Omics Quantized Auto Encoder"

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -1,0 +1,103 @@
+Getting started
+===============
+
+This page walks through installing OQAE and running the end-to-end workflow:
+train a model on raw counts, encode cells into discrete codes, and decode codes
+back into expression. Every step is exercised by the runnable scripts under
+`examples/ <https://github.com/mengerj/oqae/tree/main/examples>`_.
+
+Installation
+------------
+
+OQAE uses `uv <https://docs.astral.sh/uv/>`_ for environment management:
+
+.. code-block:: bash
+
+   make setup-env          # uv sync --all-extras  (creates .venv)
+   source .venv/bin/activate
+
+To build these docs locally, install the ``docs`` extra and run the
+``docs`` target:
+
+.. code-block:: bash
+
+   uv sync --extra docs
+   make docs               # sphinx-build -> docs/_build/html
+
+Core concepts
+-------------
+
+- **Raw counts in.** OQAE ingests **unnormalized counts**; ``log1p`` /
+  depth normalization happen *inside* the model. Do not pre-normalize.
+- **Size factors.** Decoding needs a per-cell *size factor* (observed depth) so
+  the decoder reconstructs depth-appropriate counts. ``encode`` returns it
+  alongside the codes.
+- **Discrete codes.** A cell's representation is an ``int64``
+  ``(n_cells, n_codebooks)`` array — column ``j`` is the index chosen from
+  residual codebook ``j``. This *is* the universal latent code.
+- **Organism-aware.** A model carries a fixed :class:`~omvqvae.data.GeneVocabulary`
+  (organism + ordered gene ids); v1 trains one model per organism.
+
+Train on a local AnnData
+------------------------
+
+Derive a :class:`~omvqvae.data.GeneVocabulary` from your file's genes, build a
+:class:`~omvqvae.models.OmicsVQVAE`, and run the source-agnostic
+:func:`~omvqvae.train.train` loop. See
+`examples/01_train_local_anndata.py
+<https://github.com/mengerj/oqae/blob/main/examples/01_train_local_anndata.py>`_.
+
+The same run is a one-liner via the CLI (installed as the ``oqae-train``
+console script):
+
+.. code-block:: bash
+
+   oqae-train configs/train_toy.yaml -s data.path=your_cells.h5ad
+
+Train at scale by streaming the Census
+--------------------------------------
+
+:func:`~omvqvae.data.build_census_dataloader` streams raw counts from the CZ
+CELLxGENE Census via TileDB-SOMA behind the same ``Minibatch`` contract as the
+local loader. See `examples/03_census_streaming.py
+<https://github.com/mengerj/oqae/blob/main/examples/03_census_streaming.py>`_
+(network access required).
+
+Encode and decode discrete codes
+--------------------------------
+
+Once a model is trained (or loaded with
+:func:`~omvqvae.hf_utils.load_pretrained`), the :mod:`omvqvae.inference` API
+turns expression into codes and back:
+
+.. code-block:: python
+
+   from omvqvae.inference import encode, decode
+
+   encoded = encode(model, counts)          # -> EncodedCells (codes + size factors)
+   codes = encoded.codes                    # (n_cells, n_codebooks) int64
+   counts_hat = decode(model, encoded)      # codes -> expected counts
+
+:func:`~omvqvae.inference.encode_anndata` aligns a local AnnData to the model's
+gene vocabulary first; :func:`~omvqvae.inference.decode_to_params` exposes the
+full decoder distribution for sampling/generation. The full walk-through —
+inspecting codebook usage and generating a novel profile from edited codes — is
+in `examples/02_inspect_and_generate_codes.py
+<https://github.com/mengerj/oqae/blob/main/examples/02_inspect_and_generate_codes.py>`_.
+
+Save and share a model
+----------------------
+
+:func:`~omvqvae.hf_utils.save_pretrained` writes a HuggingFace-style directory
+(``config.json`` + ``pytorch_model.bin``) capturing the model, its codebooks,
+and the gene vocabulary; :func:`~omvqvae.hf_utils.load_pretrained` rebuilds the
+exact model and feature space. :func:`~omvqvae.hf_utils.push_to_hub` /
+:func:`~omvqvae.hf_utils.from_pretrained` are thin Hub wrappers over the same
+serialization.
+
+Next steps
+----------
+
+- Browse the full :doc:`api` reference.
+- Run the `example scripts <https://github.com/mengerj/oqae/tree/main/examples>`_
+  end to end on tiny synthetic data.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,41 @@
+OQAE — Omics Quantized Auto Encoder
+===================================
+
+**OQAE** (Omics Quantized Auto Encoder) learns a **discrete, universal latent
+space for single-cell omics** with a residual VQ-VAE. Each scRNA-seq cell is
+encoded as a small set of discrete codes (indices into learned codebooks); a
+generative decoder turns those codes back into expression. The codes are a
+compact, composable "vocabulary" of expression patterns, enabling
+representation learning, compression, integration, and in-silico generation
+from a shared latent space.
+
+The Python package is :mod:`omvqvae` (distribution name ``oqae``).
+
+Highlights
+----------
+
+- **Discrete universal latent space** — every cell becomes a set of discrete
+  codes drawn from shared codebooks.
+- **Train at scale by streaming** — stream millions of cells directly from the
+  CZ CELLxGENE Census via TileDB-SOMA, or train on a local ``.h5ad`` / ``.zarr``
+  AnnData with the same interface.
+- **Raw counts in, counts out** — model raw counts directly with a Negative
+  Binomial / Zero-Inflated NB likelihood; library size is handled internally.
+- **Organism-aware** — human and mouse, each with its own gene space (one model
+  per organism in v1).
+- **HuggingFace Hub + W&B** — share models and codebooks; track runs offline or
+  with Weights & Biases.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents
+
+   getting_started
+   api
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,17 @@ module = [
 ]
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+# Sphinx (installed via the ``docs`` extra) is never imported by ``omvqvae`` but
+# is reachable in mypy's transitive import graph. Don't follow into its source:
+# recent Sphinx uses PEP 695 ``type`` statements that fail to parse under the
+# pinned 3.11 grammar (only surfaces on a 3.12 interpreter).
+module = [
+    "sphinx.*",
+]
+follow_imports = "skip"
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py", "*_test.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,10 @@ dev = [
     "pre-commit>=3.4.0",
     "coverage>=7.3.0",
 ]
+docs = [
+    "sphinx>=7.0.0",
+    "furo>=2024.1.29",
+]
 
 [project.scripts]
 oqae-train = "omvqvae.train.cli:main"

--- a/src/omvqvae/inference/codes.py
+++ b/src/omvqvae/inference/codes.py
@@ -5,10 +5,10 @@ This is the user-facing latent interface on top of a trained
 :class:`~omvqvae.models.vqvae.OmicsVQVAE`: it turns expression into the model's
 **discrete universal codes** and turns codes back into expression.
 
-```
-counts ──encode──► codes (n_cells, n_codebooks)  ──decode──► expected counts
-                   + per-cell size factor
-```
+.. code-block:: text
+
+    counts ──encode──► codes (n_cells, n_codebooks)  ──decode──► expected counts
+                       + per-cell size factor
 
 The two halves enable the universal-latent use cases:
 

--- a/src/omvqvae/models/vqvae.py
+++ b/src/omvqvae/models/vqvae.py
@@ -6,10 +6,10 @@ vector quantizer (:mod:`omvqvae.layers.residual_vq`) and the reconstruction
 heads (:mod:`omvqvae.models.likelihoods`) — into a single
 :class:`torch.nn.Module`:
 
-```
-raw counts ─► (internal log1p) ─► Encoder ─► ResidualVQ ─► Decoder ─► NB/ZINB
-                                              (discrete codes)         params
-```
+.. code-block:: text
+
+    raw counts ─► (internal log1p) ─► Encoder ─► ResidualVQ ─► Decoder ─► NB/ZINB
+                                                  (discrete codes)         params
 
 The model ingests **raw counts** and an observed per-cell **size factor**. An
 internal ``log1p`` transform is applied to the encoder input for numerical

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,18 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "accessible-pygments"
+version = "0.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c1/bbac6a50d02774f91572938964c582fff4270eee73ab822a4aeea4d8b11b/accessible_pygments-0.0.5.tar.gz", hash = "sha256:40918d3e6a2b619ad424cb91e556bd3bd8865443d9f22f1dcdf79e33c8046872", size = 1377899, upload-time = "2024-05-10T11:23:10.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/3f/95338030883d8c8b91223b4e21744b04d11b161a3ef117295d8241f50ab4/accessible_pygments-0.0.5-py3-none-any.whl", hash = "sha256:88ae3211e68a1d0b011504b2ffc1691feafce124b845bd072ab6f9f66f34d4b7", size = 1395903, upload-time = "2024-05-10T11:23:08.421Z" },
+]
+
+[[package]]
 name = "aiobotocore"
 version = "3.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -175,6 +187,15 @@ wheels = [
 ]
 
 [[package]]
+name = "alabaster"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/f8/d9c74d0daf3f742840fd818d69cfae176fa332022fd44e3469487d5a9420/alabaster-1.0.0.tar.gz", hash = "sha256:c00dca57bca26fa62a6d7d0a9fcce65f3e026e9bfe33e9c538fd3fbb2144fd9e", size = 24210, upload-time = "2024-07-26T18:15:03.762Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/b3/6b4067be973ae96ba0d615946e314c5ae35f9f993eca561b356540bb0c2b/alabaster-1.0.0-py3-none-any.whl", hash = "sha256:fc6786402dc3fcb2de3cabd5fe455a2db534b371124f1f21de8731783dec828b", size = 13929, upload-time = "2024-07-26T18:15:02.05Z" },
+]
+
+[[package]]
 name = "anndata"
 version = "0.12.17"
 source = { registry = "https://pypi.org/simple" }
@@ -302,6 +323,28 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/50/d8/30873d2b7b57dee9263e53d142da044c4600a46f2d28374b3e38b023df16/autopep8-2.3.2.tar.gz", hash = "sha256:89440a4f969197b69a995e4ce0661b031f455a9f776d2c5ba3dbd83466931758", size = 92210, upload-time = "2025-01-14T14:46:18.454Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/43/53afb8ba17218f19b77c7834128566c5bbb100a0ad9ba2e8e89d089d7079/autopep8-2.3.2-py2.py3-none-any.whl", hash = "sha256:ce8ad498672c845a0c3de2629c15b635ec2b05ef8177a6e7c91c74f3e9b51128", size = 45807, upload-time = "2025-01-14T14:46:15.466Z" },
+]
+
+[[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
+]
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/65/318323f98dbee45d42dff61d8f047181bc6f2268a9068cfad035a46be5af/beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7", size = 632571, upload-time = "2026-06-07T16:44:20.453Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl", hash = "sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9", size = 109924, upload-time = "2026-06-07T16:44:21.566Z" },
 ]
 
 [[package]]
@@ -773,6 +816,15 @@ wheels = [
 ]
 
 [[package]]
+name = "docutils"
+version = "0.22.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
+]
+
+[[package]]
 name = "donfig"
 version = "0.8.1.post1"
 source = { registry = "https://pypi.org/simple" }
@@ -991,6 +1043,23 @@ wheels = [
 ]
 
 [[package]]
+name = "furo"
+version = "2025.12.19"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "accessible-pygments" },
+    { name = "beautifulsoup4" },
+    { name = "pygments" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "sphinx-basic-ng" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/20/5f5ad4da6a5a27c80f2ed2ee9aee3f9e36c66e56e21c00fde467b2f8f88f/furo-2025.12.19.tar.gz", hash = "sha256:188d1f942037d8b37cd3985b955839fea62baa1730087dc29d157677c857e2a7", size = 1661473, upload-time = "2025-12-19T17:34:40.889Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/b2/50e9b292b5cac13e9e81272c7171301abc753a60460d21505b606e15cf21/furo-2025.12.19-py3-none-any.whl", hash = "sha256:bb0ead5309f9500130665a26bee87693c41ce4dbdff864dbfb6b0dae4673d24f", size = 339262, upload-time = "2025-12-19T17:34:38.905Z" },
+]
+
+[[package]]
 name = "gitdb"
 version = "4.0.12"
 source = { registry = "https://pypi.org/simple" }
@@ -1201,6 +1270,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "imagesize"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/e6/7bf14eeb8f8b7251141944835abd42eb20a658d89084b7e1f3e5fe394090/imagesize-2.0.0.tar.gz", hash = "sha256:8e8358c4a05c304f1fccf7ff96f036e7243a189e9e42e90851993c558cfe9ee3", size = 1773045, upload-time = "2026-03-03T14:18:29.941Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/53/fb7122b71361a0d121b669dcf3d31244ef75badbbb724af388948de543e2/imagesize-2.0.0-py2.py3-none-any.whl", hash = "sha256:5667c5bbb57ab3f1fa4bc366f4fbc971db3d5ed011fd2715fd8001f782718d96", size = 9441, upload-time = "2026-03-03T14:18:27.892Z" },
 ]
 
 [[package]]
@@ -2209,6 +2287,11 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
 ]
+docs = [
+    { name = "furo" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -2218,6 +2301,7 @@ requires-dist = [
     { name = "cellxgene-census", specifier = ">=1.15.0" },
     { name = "coverage", marker = "extra == 'dev'", specifier = ">=7.3.0" },
     { name = "flake8", marker = "extra == 'dev'", specifier = ">=6.0.0" },
+    { name = "furo", marker = "extra == 'docs'", specifier = ">=2024.1.29" },
     { name = "huggingface-hub", specifier = ">=0.20.0" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.12.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.5.0" },
@@ -2229,6 +2313,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "scipy", specifier = ">=1.9.0" },
+    { name = "sphinx", marker = "extra == 'docs'", specifier = ">=7.0.0" },
     { name = "tiledbsoma", specifier = ">=1.12.0" },
     { name = "tiledbsoma-ml", specifier = ">=0.1.0" },
     { name = "torch", specifier = ">=2.12.1" },
@@ -2237,7 +2322,7 @@ requires-dist = [
     { name = "wandb", specifier = ">=0.21.0" },
     { name = "zarr", specifier = ">=3.0.0" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["dev", "docs"]
 
 [[package]]
 name = "packaging"
@@ -3084,6 +3169,15 @@ wheels = [
 ]
 
 [[package]]
+name = "roman-numerals"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/f9/41dc953bbeb056c17d5f7a519f50fdf010bd0553be2d630bc69d1e022703/roman_numerals-4.1.0.tar.gz", hash = "sha256:1af8b147eb1405d5839e78aeb93131690495fe9da5c91856cb33ad55a7f1e5b2", size = 9077, upload-time = "2025-12-17T18:25:34.381Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl", hash = "sha256:647ba99caddc2cc1e55a51e4360689115551bf4476d90e8162cf8c345fe233c7", size = 7676, upload-time = "2025-12-17T18:25:33.098Z" },
+]
+
+[[package]]
 name = "s3fs"
 version = "2026.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3475,6 +3569,15 @@ wheels = [
 ]
 
 [[package]]
+name = "snowballstemmer"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/f8/0a71edf031f03c40db17503cb8ca78a69a171254e568e7db241b0ab57ea1/snowballstemmer-3.1.1.tar.gz", hash = "sha256:e07bbc54a0d798fe6010a12398422e62a8bfbba95c394fd0956ef58cb4d3e260", size = 123314, upload-time = "2026-06-03T00:56:40.194Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/07/2ebca9b11fb9be7340a818d8d6f63feaebb146be2c4afbd6061701d6df6e/snowballstemmer-3.1.1-py3-none-any.whl", hash = "sha256:7e207fa178741da09cdee59d3ecec3827ad5f92b1fc5c9ff3755b639f71f5752", size = 104164, upload-time = "2026-06-03T00:56:38.614Z" },
+]
+
+[[package]]
 name = "somacore"
 version = "1.0.29"
 source = { registry = "https://pypi.org/simple" }
@@ -3492,6 +3595,145 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6b/32/dbb9873dea1513499e1bf47b0cf1302645cbae25741d278c6412fc947d47/somacore-1.0.29.tar.gz", hash = "sha256:93ef9f4d1ba88925ddb5f1772d465b9d8ce96bec329bc2ad9de44d7857e13126", size = 31676, upload-time = "2025-06-16T17:57:31.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/29/32/f99009be2e40d2098daae9be8374dde5d976d8af145024758737af0024ab/somacore-1.0.29-py3-none-any.whl", hash = "sha256:5bb91a9c8b36d45fbe408b39311ccc09ae43fb418b322ea5d025e119b0c7d639", size = 38602, upload-time = "2025-06-16T17:57:30.315Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
+]
+
+[[package]]
+name = "sphinx"
+version = "9.0.4"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12'",
+]
+dependencies = [
+    { name = "alabaster", marker = "python_full_version < '3.12'" },
+    { name = "babel", marker = "python_full_version < '3.12'" },
+    { name = "colorama", marker = "python_full_version < '3.12' and sys_platform == 'win32'" },
+    { name = "docutils", marker = "python_full_version < '3.12'" },
+    { name = "imagesize", marker = "python_full_version < '3.12'" },
+    { name = "jinja2", marker = "python_full_version < '3.12'" },
+    { name = "packaging", marker = "python_full_version < '3.12'" },
+    { name = "pygments", marker = "python_full_version < '3.12'" },
+    { name = "requests", marker = "python_full_version < '3.12'" },
+    { name = "roman-numerals", marker = "python_full_version < '3.12'" },
+    { name = "snowballstemmer", marker = "python_full_version < '3.12'" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.12'" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.12'" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.12'" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.12'" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.12'" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/50/a8c6ccc36d5eacdfd7913ddccd15a9cee03ecafc5ee2bc40e1f168d85022/sphinx-9.0.4.tar.gz", hash = "sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3", size = 8710502, upload-time = "2025-12-04T07:45:27.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/3f/4bbd76424c393caead2e1eb89777f575dee5c8653e2d4b6afd7a564f5974/sphinx-9.0.4-py3-none-any.whl", hash = "sha256:5bebc595a5e943ea248b99c13814c1c5e10b3ece718976824ffa7959ff95fffb", size = 3917713, upload-time = "2025-12-04T07:45:24.944Z" },
+]
+
+[[package]]
+name = "sphinx"
+version = "9.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.15'",
+    "python_full_version >= '3.12' and python_full_version < '3.15'",
+]
+dependencies = [
+    { name = "alabaster", marker = "python_full_version >= '3.12'" },
+    { name = "babel", marker = "python_full_version >= '3.12'" },
+    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
+    { name = "docutils", marker = "python_full_version >= '3.12'" },
+    { name = "imagesize", marker = "python_full_version >= '3.12'" },
+    { name = "jinja2", marker = "python_full_version >= '3.12'" },
+    { name = "packaging", marker = "python_full_version >= '3.12'" },
+    { name = "pygments", marker = "python_full_version >= '3.12'" },
+    { name = "requests", marker = "python_full_version >= '3.12'" },
+    { name = "roman-numerals", marker = "python_full_version >= '3.12'" },
+    { name = "snowballstemmer", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/f7/b1884cb3188ab181fc81fa00c266699dab600f927a964df02ec3d5d1916a/sphinx-9.1.0-py3-none-any.whl", hash = "sha256:c84fdd4e782504495fe4f2c0b3413d6c2bf388589bb352d439b2a3bb99991978", size = 3921742, upload-time = "2025-12-31T15:09:25.561Z" },
+]
+
+[[package]]
+name = "sphinx-basic-ng"
+version = "1.0.0b2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/0b/a866924ded68efec7a1759587a4e478aec7559d8165fac8b2ad1c0e774d6/sphinx_basic_ng-1.0.0b2.tar.gz", hash = "sha256:9ec55a47c90c8c002b5960c57492ec3021f5193cb26cebc2dc4ea226848651c9", size = 20736, upload-time = "2023-07-08T18:40:54.166Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/dd/018ce05c532a22007ac58d4f45232514cd9d6dd0ee1dc374e309db830983/sphinx_basic_ng-1.0.0b2-py3-none-any.whl", hash = "sha256:eb09aedbabfb650607e9b4b68c9d240b90b1e1be221d6ad71d61c52e29f7932b", size = 22496, upload-time = "2023-07-08T18:40:52.659Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-applehelp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/6e/b837e84a1a704953c62ef8776d45c3e8d759876b4a84fe14eba2859106fe/sphinxcontrib_applehelp-2.0.0.tar.gz", hash = "sha256:2f29ef331735ce958efa4734873f084941970894c6090408b079c61b2e1c06d1", size = 20053, upload-time = "2024-07-29T01:09:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/85/9ebeae2f76e9e77b952f4b274c27238156eae7979c5421fba91a28f4970d/sphinxcontrib_applehelp-2.0.0-py3-none-any.whl", hash = "sha256:4cd3f0ec4ac5dd9c17ec65e9ab272c9b867ea77425228e68ecf08d6b28ddbdb5", size = 119300, upload-time = "2024-07-29T01:08:58.99Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-devhelp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/d2/5beee64d3e4e747f316bae86b55943f51e82bb86ecd325883ef65741e7da/sphinxcontrib_devhelp-2.0.0.tar.gz", hash = "sha256:411f5d96d445d1d73bb5d52133377b4248ec79db5c793ce7dbe59e074b4dd1ad", size = 12967, upload-time = "2024-07-29T01:09:23.417Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/7a/987e583882f985fe4d7323774889ec58049171828b58c2217e7f79cdf44e/sphinxcontrib_devhelp-2.0.0-py3-none-any.whl", hash = "sha256:aefb8b83854e4b0998877524d1029fd3e6879210422ee3780459e28a1f03a8a2", size = 82530, upload-time = "2024-07-29T01:09:21.945Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-htmlhelp"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/93/983afd9aa001e5201eab16b5a444ed5b9b0a7a010541e0ddfbbfd0b2470c/sphinxcontrib_htmlhelp-2.1.0.tar.gz", hash = "sha256:c9e2916ace8aad64cc13a0d233ee22317f2b9025b9cf3295249fa985cc7082e9", size = 22617, upload-time = "2024-07-29T01:09:37.889Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/7b/18a8c0bcec9182c05a0b3ec2a776bba4ead82750a55ff798e8d406dae604/sphinxcontrib_htmlhelp-2.1.0-py3-none-any.whl", hash = "sha256:166759820b47002d22914d64a075ce08f4c46818e17cfc9470a9786b759b19f8", size = 98705, upload-time = "2024-07-29T01:09:36.407Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-jsmath"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/e8/9ed3830aeed71f17c026a07a5097edcf44b692850ef215b161b8ad875729/sphinxcontrib-jsmath-1.0.1.tar.gz", hash = "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8", size = 5787, upload-time = "2019-01-21T16:10:16.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl", hash = "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178", size = 5071, upload-time = "2019-01-21T16:10:14.333Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-qthelp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/bc/9104308fc285eb3e0b31b67688235db556cd5b0ef31d96f30e45f2e51cae/sphinxcontrib_qthelp-2.0.0.tar.gz", hash = "sha256:4fe7d0ac8fc171045be623aba3e2a8f613f8682731f9153bb2e40ece16b9bbab", size = 17165, upload-time = "2024-07-29T01:09:56.435Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/83/859ecdd180cacc13b1f7e857abf8582a64552ea7a061057a6c716e790fce/sphinxcontrib_qthelp-2.0.0-py3-none-any.whl", hash = "sha256:b18a828cdba941ccd6ee8445dbe72ffa3ef8cbe7505d8cd1fa0d42d3f2d5f3eb", size = 88743, upload-time = "2024-07-29T01:09:54.885Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-serializinghtml"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/44/6716b257b0aa6bfd51a1b31665d1c205fb12cb5ad56de752dfa15657de2f/sphinxcontrib_serializinghtml-2.0.0.tar.gz", hash = "sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d", size = 16080, upload-time = "2024-07-29T01:10:09.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl", hash = "sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331", size = 92072, upload-time = "2024-07-29T01:10:08.203Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description
Adds a Sphinx documentation scaffold that renders the existing NumPy-style
docstrings across the public `omvqvae` API. Completes **PR #8 slice 2** (the docs
half of "Examples & Documentation") — slice 1 (example scripts) already landed,
so **PR #8 is now complete**.

## Type of change
- [x] Documentation update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (no functional changes)

## Implementation
### Changes made:
- **`docs/source/conf.py`** — Sphinx config: `autodoc` + `napoleon` (NumPy
  docstrings) + `viewcode` + `intersphinx`, `furo` theme. Imports the package
  from the in-tree `src/` layout and mocks the heavy Census deps
  (`cellxgene_census`, `tiledbsoma`, `tiledbsoma_ml`) so the build is fast/robust.
- **`docs/source/index.rst`** — landing page (overview + highlights + toctree).
- **`docs/source/getting_started.rst`** — narrative walk-through (install → train
  local / Census → encode/decode → save/share) linking the `examples/` scripts.
- **`docs/source/api.rst`** — autodoc of the full public API by *implementation*
  module (`data.dataset`/`normalize`/`anndata_io`/`census`, `layers.residual_vq`,
  `models.likelihoods`/`vqvae`, `train.loop`/`cli`, `inference.codes`,
  `hf_utils`, `utils.tracking`).
- **`Makefile`** — `make docs` / `make docs-clean` targets
  (`sphinx-build -W --keep-going` → `docs/_build/html`, already gitignored).
- **`.github/workflows/ci.yml`** — a dedicated `docs` job builds the docs
  warnings-as-errors so they stay buildable.
- **`pyproject.toml`** — new `docs` extra (`sphinx>=7`, `furo`); `uv.lock` refreshed.
- **`src/omvqvae/models/vqvae.py`, `src/omvqvae/inference/codes.py`** — converted
  the Markdown code fences in two module docstrings to RST literal blocks so the
  build is warning-clean (no behavioral change).
- Updated `docs/STATUS.md` and `docs/PROJECT_PLAN.md` (PR #8 done, decisions-log
  entry, next task = PR #9 benchmarking & scaling).

### Architecture decisions:
- Autodoc the **implementation modules**, not the re-exporting package `__init__`s
  — autodoc skips imported members by default, so the `__init__`s would document
  nothing. This surfaces the actual classes/functions.
- Build **warnings-as-errors in CI now** (one cheap `docs` job) rather than
  deferring the optional CI-docs check to PR #10, so docstring rot becomes a CI
  failure instead of accumulating until release.
- `getting_started.rst` **links** the `examples/` scripts on GitHub rather than
  `literalinclude`-ing them across the source tree.

## Testing
- [ ] Tests added/updated (none needed — docs scaffold; no `src` behavior change)
- [x] All tests pass locally (`make ci` green, 184 passed)
- [x] Test coverage maintained
- [x] Manual testing completed (`make docs` builds clean, warnings-as-errors)

### Test coverage:
- Current coverage: ~99.7%
- Coverage change: no change

## Code Quality
- [x] Code follows project style guidelines
- [x] Self-review of the code completed
- [x] No new linter warnings
- [x] Type hints added for new code

## Documentation
- [x] Documentation updated — this PR *is* the documentation scaffold
- [x] API documentation updated (autodoc over the public API)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings (docs build is warnings-as-errors)
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011PY5FQqbhmKCbQwwLdBHcM)_