### PR TITLE
Benchmark eval upgrades: quantization gap, scIB metrics, UMAP (#36)

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -4,7 +4,7 @@
 > end of every working session** so the next session can pick up cold. Keep it
 > short; deep rationale lives in `docs/PROJECT_PLAN.md`.
 
-**Last updated:** 2026-06-30
+**Last updated:** 2026-07-01
 
 ## Current state
 
@@ -271,6 +271,33 @@
     optimizer+clip, the reporting helpers, and `BenchmarkConfig` → step-fn
     round-trip) plus the example import smoke test; `make ci` green (~99.8%),
     `make docs` clean. **PR #9 is now complete.**
+- **Benchmark eval upgrades (issue #36) — DONE (this PR, branch
+  `claude/eval-upgrades`).** Adds offline latent-quality metrics so we can judge
+  a model beyond nearest-centroid separability. Three pieces:
+  - **Quantization-cost view.** `inference.encode` / `EncodedCells` now also
+    return `quantized` (the post-quantization latent, i.e. the codes embedded
+    back into latent space; free — same `model.quantize(z)` call). `evaluate_model`
+    reports `separability` (continuous `z`), `separability_quantized`, and their
+    `separability_gap` — how much biology the RVQ bottleneck discards. Surfaced in
+    `results_to_dicts` and the Markdown table (`sep_quant` / `sep_gap` columns).
+  - **scIB clustering metrics.** `benchmark/clustering.py::clustering_metrics`
+    (NMI / ARI via KMeans + cell-type ASW) using the new **optional `benchmark`
+    extra** (`scib-metrics`, `umap-learn`, `matplotlib`; `uv.lock` refreshed).
+    Lazy-imported; opt-in via `evaluate_model(..., compute_clustering=True)` /
+    `run_benchmark` / `run_suite`. Off by default so the core path never imports
+    jax/scib. The `nmi` / `ari` / `ct_asw` table columns appear only when
+    computed.
+  - **UMAP viz.** `benchmark/viz.py::plot_latent_umap` (+ `compute_umap`) —
+    grid of UMAP scatters, rows = `latent` / `quantized`, columns = `labels` /
+    `color_by` (batch view). Works on the continuous representations; raw integer
+    codes are intentionally not UMAP'd (Euclidean on codebook indices is
+    meaningless).
+  - New exports on `omvqvae.benchmark`. `examples/latent_quality.py` demonstrates
+    `compute_clustering=True` + a saved UMAP. Tests: clustering/viz guarded with
+    `importorskip` (run in CI since all extras are installed); Part A tests are
+    unconditional. `make ci` green (249 passed, ~99.6%).
+  - **Follow-up (issue #37):** scVI baseline behind a `LatentModel` protocol,
+    reusing these shared latent metrics.
 
 ## Next task — PR #10: v1.0 release
 

--- a/examples/07_latent_quality.py
+++ b/examples/07_latent_quality.py
@@ -1,0 +1,122 @@
+"""
+Example 7 — latent-quality evaluation (quantization gap, scIB metrics, UMAP).
+
+Extends the config sweep of example 4 with the offline latent-quality metrics
+from issue #36, so you can judge a model beyond nearest-centroid separability:
+
+- the **quantization-cost** view — ``separability`` (continuous latent) vs
+  ``sep_quant`` (post-quantization latent) and their ``sep_gap``;
+- **scIB clustering** metrics (NMI / ARI / cell-type ASW) via
+  ``compute_clustering=True``;
+- a **UMAP** of the trained latent (continuous vs post-quantization), coloured by
+  the known "program" and by "batch".
+
+The clustering + UMAP pieces need the optional ``benchmark`` extra
+(``uv sync --extra benchmark``); pass ``compute_clustering=False`` /
+``make_umap=False`` to skip them on a core install.
+
+Run::
+
+    python examples/07_latent_quality.py
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List, Optional, Tuple
+
+from synthetic_data import make_synthetic_anndata
+
+from omvqvae.benchmark import (
+    BenchmarkConfig,
+    format_results_table,
+    plot_latent_umap,
+    run_suite,
+)
+from omvqvae.data import GeneVocabulary, build_anndata_dataloader, extract_counts
+from omvqvae.inference import encode
+from omvqvae.models.vqvae import OmicsVQVAE
+from omvqvae.train import TrainConfig, train
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from matplotlib.figure import Figure
+
+
+def main(
+    *,
+    compute_clustering: bool = True,
+    make_umap: bool = True,
+) -> Tuple[str, Optional["Figure"]]:
+    """
+    Sweep a couple of configs, tabulate the quality metrics, and (optionally) plot.
+
+    Parameters
+    ----------
+    compute_clustering : bool, default True
+        Also compute NMI / ARI / cell-type ASW (needs the ``benchmark`` extra).
+    make_umap : bool, default True
+        Train the best config once more and render a latent UMAP figure.
+
+    Returns
+    -------
+    (str, matplotlib.figure.Figure or None)
+        The rendered comparison table and the UMAP figure (``None`` when
+        ``make_umap`` is False).
+    """
+    organism = "homo_sapiens"
+    adata = make_synthetic_anndata(
+        n_cells=256, n_genes=40, n_programs=4, organism=organism
+    )
+    counts, gene_ids = extract_counts(adata)
+    vocabulary = GeneVocabulary(organism, gene_ids)
+    labels = list(adata.obs["program"])
+    batches = list(adata.obs["batch"])
+    loader = build_anndata_dataloader(
+        adata, vocabulary, batch_size=64, shuffle=True, batch_key="batch"
+    )
+
+    configs: List[BenchmarkConfig] = [
+        BenchmarkConfig(
+            name="nb-2x64", likelihood="nb", n_codebooks=2, codebook_size=64
+        ),
+        BenchmarkConfig(
+            name="nb-1x16", likelihood="nb", n_codebooks=1, codebook_size=16
+        ),
+    ]
+
+    # The quantization gap + scIB metrics land in the table (sep_quant / sep_gap;
+    # nmi / ari / ct_asw when clustering is requested).
+    results = run_suite(
+        configs,
+        loader,
+        n_genes=vocabulary.n_genes,
+        eval_counts=counts,
+        eval_labels=labels,
+        compute_clustering=compute_clustering,
+    )
+    table = format_results_table(results)
+    print(table)
+
+    if not make_umap:
+        return table, None
+
+    # run_suite does not return the trained models, so re-fit the lowest-NLL
+    # config to grab its latent for the figure.
+    best = min(results, key=lambda r: r.eval.reconstruction.nll).config
+    model = OmicsVQVAE(vocabulary.n_genes, **best.model_kwargs())
+    train(model, loader, config=TrainConfig(max_epochs=best.max_epochs))
+    encoded = encode(model, counts)
+    fig = plot_latent_umap(
+        encoded.latent,
+        labels,
+        color_by=batches,
+        quantized=encoded.quantized,
+        n_neighbors=15,
+    )
+    return table, fig
+
+
+if __name__ == "__main__":
+    _, figure = main()
+    if figure is not None:
+        figure.savefig("latent_umap.png", dpi=150, bbox_inches="tight")
+        print("wrote latent_umap.png")

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,6 +13,7 @@ CELLxGENE Census and need network access.
 | 4 | [`04_benchmark_configs.py`](04_benchmark_configs.py) | Benchmark likelihood / codebook configs on shared data and print a comparison table (reconstruction, codebook utilization, separability). | ✅ |
 | 5 | [`05_benchmark_report.py`](05_benchmark_report.py) | Run the full PR #9 sweep (NB vs ZINB vs Gaussian, codebook sweeps) on a larger fixture and write the interpreted [`docs/benchmark_report.md`](../docs/benchmark_report.md). | ✅ |
 | 6 | [`06_census_throughput.py`](06_census_throughput.py) | Profile Census streaming throughput (cells/s, time-to-first-batch) — raw streaming vs end-to-end with a model train step. | ❌ (network) |
+| 7 | [`07_latent_quality.py`](07_latent_quality.py) | Latent-quality metrics: quantization gap (continuous vs post-quantization separability), scIB clustering (NMI / ARI / cell-type ASW), and a latent UMAP. Needs the `benchmark` extra. | ✅ |
 
 ## Running
 
@@ -25,6 +26,7 @@ uv run python examples/03_census_streaming.py   # requires network (Census)
 uv run python examples/04_benchmark_configs.py
 uv run python examples/05_benchmark_report.py   # writes docs/benchmark_report.md
 uv run python examples/06_census_throughput.py  # requires network (Census)
+uv run python examples/07_latent_quality.py      # needs the `benchmark` extra
 ```
 
 Each script exposes a `main()` function, so it can also be imported and driven

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,13 @@ docs = [
     "sphinx>=7.0.0",
     "furo>=2024.1.29",
 ]
+# Optional heavy deps for the offline benchmarking extras (clustering + UMAP).
+# Not installed by default so `import omvqvae` and the core suite stay light.
+benchmark = [
+    "scib-metrics>=0.5.0",
+    "umap-learn>=0.5.4",
+    "matplotlib>=3.7.0",
+]
 
 [project.scripts]
 oqae-train = "omvqvae.train.cli:main"
@@ -119,6 +126,8 @@ module = [
     "cellxgene_census.*",
     "tiledbsoma.*",
     "tiledbsoma_ml.*",
+    "scib_metrics.*",
+    "umap.*",
 ]
 ignore_missing_imports = true
 

--- a/src/omvqvae/benchmark/__init__.py
+++ b/src/omvqvae/benchmark/__init__.py
@@ -15,6 +15,7 @@ stream later.
 
 from __future__ import annotations
 
+from omvqvae.benchmark.clustering import ClusteringMetrics, clustering_metrics
 from omvqvae.benchmark.harness import (
     BenchmarkConfig,
     BenchmarkResult,
@@ -46,6 +47,7 @@ from omvqvae.benchmark.throughput import (
     measure_stream_throughput,
     throughput_to_dicts,
 )
+from omvqvae.benchmark.viz import compute_umap, plot_latent_umap
 
 __all__ = [
     "BenchmarkConfig",
@@ -61,6 +63,10 @@ __all__ = [
     "codebook_usage",
     "reconstruction_metrics",
     "separability_score",
+    "ClusteringMetrics",
+    "clustering_metrics",
+    "compute_umap",
+    "plot_latent_umap",
     "ReportFixture",
     "make_benchmark_fixture",
     "default_report_configs",

--- a/src/omvqvae/benchmark/clustering.py
+++ b/src/omvqvae/benchmark/clustering.py
@@ -1,0 +1,150 @@
+"""
+Clustering-based biology metrics for the OQAE benchmarking harness.
+
+The harness's built-in :func:`omvqvae.benchmark.metrics.separability_score` is a
+fast, dependency-free *nearest-centroid* proxy: it only rewards convex,
+roughly-spherical label clusters and under-reports quality on continuum tissues
+(e.g. bone-marrow progenitors, whose class means sit close together). This module
+adds the stronger, community-standard measures used by scIB — NMI / ARI between
+labels and an unsupervised clustering of the latent, plus the cell-type average
+silhouette width — which capture non-convex structure.
+
+These metrics require the optional :mod:`scib_metrics` dependency (installed via
+the ``benchmark`` extra: ``uv sync --extra benchmark`` /
+``pip install 'oqae[benchmark]'``). It is a heavy dependency, so it is
+**lazy-imported** inside :func:`clustering_metrics`; ``import omvqvae`` and the
+offline default test suite never touch it.
+
+Everything here operates on a plain ``(n_cells, n_latent)`` embedding, so it runs
+identically over the OQAE continuous latent, the OQAE post-quantization latent
+(see :attr:`omvqvae.inference.EncodedCells.quantized`), and any external
+baseline's latent — the shared metric that makes those comparable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Sequence
+
+import numpy as np
+
+from omvqvae.utils.logging import get_logger
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from omvqvae.benchmark.metrics import LatentLike
+
+logger = get_logger(__name__)
+
+__all__ = [
+    "ClusteringMetrics",
+    "clustering_metrics",
+]
+
+_MISSING_DEP_MSG = (
+    "clustering_metrics requires the optional 'scib-metrics' dependency. "
+    "Install the benchmark extra, e.g. `uv sync --extra benchmark` or "
+    "`pip install 'oqae[benchmark]'`."
+)
+
+
+@dataclass
+class ClusteringMetrics:
+    """
+    Clustering-agreement biology metrics for a latent space given labels.
+
+    Attributes
+    ----------
+    nmi : float
+        Normalized mutual information between the labels and a KMeans clustering
+        of the latent, in ``[0, 1]`` (higher = the clustering recovers the label
+        structure).
+    ari : float
+        Adjusted Rand index between the labels and the same clustering, in
+        ``[-0.5, 1]`` (higher = better; ``0`` ≈ chance).
+    cell_type_asw : float
+        Cell-type average silhouette width, rescaled to ``[0, 1]`` (higher =
+        labels form tighter, better-separated clusters in the latent).
+    """
+
+    nmi: float
+    ari: float
+    cell_type_asw: float
+
+
+def clustering_metrics(
+    latent: "LatentLike",
+    labels: Sequence[object],
+) -> ClusteringMetrics:
+    """
+    Compute NMI / ARI / cell-type ASW for a latent space against known labels.
+
+    Parameters
+    ----------
+    latent : numpy.ndarray or torch.Tensor
+        Latent vectors of shape ``(n_cells, n_latent)`` — e.g. the OQAE
+        continuous latent (:attr:`omvqvae.inference.EncodedCells.latent`), the
+        post-quantization latent (``.quantized``), or a baseline's embedding.
+    labels : Sequence
+        Per-cell labels of length ``n_cells`` (e.g. cell type).
+
+    Returns
+    -------
+    ClusteringMetrics
+        NMI, ARI (both from a KMeans clustering of the latent), and the rescaled
+        cell-type silhouette width. All three are ``nan`` when there are fewer
+        than two distinct labels (undefined).
+
+    Raises
+    ------
+    ImportError
+        If the optional ``scib-metrics`` dependency is not installed.
+    ValueError
+        If ``latent`` is not 2-D or ``labels`` length disagrees with the number
+        of cells.
+
+    Notes
+    -----
+    The clustering is KMeans-based (scIB's ``*_kmeans`` variant), which needs no
+    graph-clustering backend (igraph/leiden) and so keeps the extra light and
+    deterministic. Metrics are computed over all cells (no held-out split); use
+    them for relative comparison across configurations / baselines.
+    """
+    try:
+        from scib_metrics import (
+            nmi_ari_cluster_labels_kmeans,
+            silhouette_label,
+        )
+    except ImportError as exc:  # pragma: no cover - exercised only without the dep
+        raise ImportError(_MISSING_DEP_MSG) from exc
+
+    array = np.asarray(_to_numpy(latent), dtype=np.float64)
+    if array.ndim != 2:
+        raise ValueError(f"latent must be 2-D (n_cells, n_latent); got {array.ndim}-D.")
+    labels_arr = np.asarray(list(labels), dtype=object)
+    if labels_arr.shape[0] != array.shape[0]:
+        raise ValueError(
+            f"labels has length {labels_arr.shape[0]} but there are "
+            f"{array.shape[0]} cells."
+        )
+    # Encode labels to contiguous integer codes (scib_metrics expects a numeric
+    # label vector); NMI/ARI/ASW are invariant to the encoding.
+    _, label_codes = np.unique(labels_arr, return_inverse=True)
+    if np.unique(label_codes).size < 2:
+        return ClusteringMetrics(
+            nmi=float("nan"), ari=float("nan"), cell_type_asw=float("nan")
+        )
+
+    nmi_ari = nmi_ari_cluster_labels_kmeans(array, label_codes)
+    asw = float(silhouette_label(array, label_codes))
+    return ClusteringMetrics(
+        nmi=float(nmi_ari["nmi"]),
+        ari=float(nmi_ari["ari"]),
+        cell_type_asw=asw,
+    )
+
+
+def _to_numpy(latent: "LatentLike") -> np.ndarray:
+    """Coerce a latent array-like to a NumPy array without importing torch."""
+    if hasattr(latent, "detach"):  # torch.Tensor without importing torch here
+        return latent.detach().cpu().numpy()
+    return np.asarray(latent)

--- a/src/omvqvae/benchmark/harness.py
+++ b/src/omvqvae/benchmark/harness.py
@@ -131,13 +131,37 @@ class EvalMetrics:
     codebook : CodebookUsage
         Codebook perplexity / utilization over the evaluation cells.
     separability : float
-        Nearest-centroid separability of the latent given the eval labels, or
-        ``nan`` when labels are absent or degenerate.
+        Nearest-centroid separability of the **continuous** pre-quantization
+        latent given the eval labels, or ``nan`` when labels are absent or
+        degenerate. Kept as the headline separability for back-compat.
+    separability_quantized : float
+        Nearest-centroid separability of the **post-quantization** latent (the
+        discrete codes embedded back into latent space), or ``nan`` under the
+        same conditions.
+    separability_gap : float
+        ``separability - separability_quantized``: how much of the label
+        structure the codebook bottleneck discards. Near ``0`` means quantization
+        is cheap; a large positive value means the codes are lossy. ``nan`` when
+        either component is ``nan``.
+    nmi : float
+        Normalized mutual information between labels and a KMeans clustering of
+        the continuous latent (scIB-style). ``nan`` unless clustering metrics are
+        requested (they need the optional ``scib-metrics`` dependency).
+    ari : float
+        Adjusted Rand index for the same clustering. ``nan`` unless requested.
+    cell_type_asw : float
+        Cell-type average silhouette width of the continuous latent, rescaled to
+        ``[0, 1]``. ``nan`` unless requested.
     """
 
     reconstruction: ReconstructionMetrics
     codebook: CodebookUsage
     separability: float
+    separability_quantized: float
+    separability_gap: float
+    nmi: float = float("nan")
+    ari: float = float("nan")
+    cell_type_asw: float = float("nan")
 
 
 @dataclass
@@ -172,6 +196,7 @@ def evaluate_model(
     eval_size_factors: Optional["SizeFactorsLike"] = None,
     eval_labels: Optional[Sequence[object]] = None,
     batch_size: int = 512,
+    compute_clustering: bool = False,
 ) -> EvalMetrics:
     """
     Compute reconstruction, codebook, and separability metrics for a model.
@@ -189,6 +214,11 @@ def evaluate_model(
         Separability is ``nan`` when omitted.
     batch_size : int, default 512
         Cells per forward pass.
+    compute_clustering : bool, default False
+        Also compute the scIB-style NMI / ARI / cell-type-ASW clustering metrics
+        on the continuous latent (requires ``eval_labels`` and the optional
+        ``scib-metrics`` dependency). Off by default so the harness stays light
+        and dependency-free unless the caller opts in.
 
     Returns
     -------
@@ -213,9 +243,32 @@ def evaluate_model(
     usage = codebook_usage(encoded.codes, model.codebook_size)
     if eval_labels is None:
         separability = float("nan")
+        separability_quantized = float("nan")
+        separability_gap = float("nan")
     else:
         separability = separability_score(encoded.latent, eval_labels)
-    return EvalMetrics(reconstruction=recon, codebook=usage, separability=separability)
+        separability_quantized = separability_score(encoded.quantized, eval_labels)
+        separability_gap = separability - separability_quantized
+
+    nmi = ari = cell_type_asw = float("nan")
+    if compute_clustering and eval_labels is not None:
+        # Lazy import keeps the optional scib-metrics dependency out of the
+        # default (offline) path.
+        from omvqvae.benchmark.clustering import clustering_metrics
+
+        cluster = clustering_metrics(encoded.latent, eval_labels)
+        nmi, ari, cell_type_asw = cluster.nmi, cluster.ari, cluster.cell_type_asw
+
+    return EvalMetrics(
+        reconstruction=recon,
+        codebook=usage,
+        separability=separability,
+        separability_quantized=separability_quantized,
+        separability_gap=separability_gap,
+        nmi=nmi,
+        ari=ari,
+        cell_type_asw=cell_type_asw,
+    )
 
 
 def run_benchmark(
@@ -227,6 +280,7 @@ def run_benchmark(
     eval_size_factors: Optional["SizeFactorsLike"] = None,
     eval_labels: Optional[Sequence[object]] = None,
     eval_batch_size: int = 512,
+    compute_clustering: bool = False,
 ) -> BenchmarkResult:
     """
     Train one configuration and evaluate it on the held-out set.
@@ -249,6 +303,9 @@ def run_benchmark(
         Per-cell eval labels for the separability score.
     eval_batch_size : int, default 512
         Cells per evaluation forward pass.
+    compute_clustering : bool, default False
+        Forwarded to :func:`evaluate_model`; opt into the scIB-style NMI / ARI /
+        cell-type-ASW metrics (needs the optional ``scib-metrics`` dependency).
 
     Returns
     -------
@@ -283,6 +340,7 @@ def run_benchmark(
         eval_size_factors=eval_size_factors,
         eval_labels=eval_labels,
         batch_size=eval_batch_size,
+        compute_clustering=compute_clustering,
     )
     return BenchmarkResult(config=config, train_loss=train_loss, eval=eval_metrics)
 
@@ -296,6 +354,7 @@ def run_suite(
     eval_size_factors: Optional["SizeFactorsLike"] = None,
     eval_labels: Optional[Sequence[object]] = None,
     eval_batch_size: int = 512,
+    compute_clustering: bool = False,
 ) -> List[BenchmarkResult]:
     """
     Run :func:`run_benchmark` for each config against shared data.
@@ -316,6 +375,9 @@ def run_suite(
         Shared held-out labels for separability.
     eval_batch_size : int, default 512
         Cells per evaluation forward pass.
+    compute_clustering : bool, default False
+        Forwarded to each :func:`run_benchmark` call (opt into NMI / ARI /
+        cell-type ASW).
 
     Returns
     -------
@@ -333,6 +395,7 @@ def run_suite(
                 eval_size_factors=eval_size_factors,
                 eval_labels=eval_labels,
                 eval_batch_size=eval_batch_size,
+                compute_clustering=compute_clustering,
             )
         )
     return results
@@ -369,6 +432,11 @@ def results_to_dicts(results: Sequence[BenchmarkResult]) -> List[Dict[str, Any]]
                 "perplexity": result.eval.codebook.perplexity,
                 "utilization": result.eval.codebook.utilization,
                 "separability": result.eval.separability,
+                "separability_quantized": result.eval.separability_quantized,
+                "separability_gap": result.eval.separability_gap,
+                "nmi": result.eval.nmi,
+                "ari": result.eval.ari,
+                "cell_type_asw": result.eval.cell_type_asw,
             }
         )
     return rows
@@ -391,6 +459,13 @@ def format_results_table(results: Sequence[BenchmarkResult]) -> str:
     if not results:
         return "(no results)"
 
+    # The scIB clustering columns are only shown when at least one result
+    # actually computed them (opt-in via ``compute_clustering``); otherwise the
+    # table stays narrow with just the always-on metrics.
+    show_clustering = any(
+        result.eval.nmi == result.eval.nmi for result in results  # not nan
+    )
+
     headers = [
         "name",
         "likelihood",
@@ -401,7 +476,11 @@ def format_results_table(results: Sequence[BenchmarkResult]) -> str:
         "perplexity",
         "utilization",
         "separability",
+        "sep_quant",
+        "sep_gap",
     ]
+    if show_clustering:
+        headers += ["nmi", "ari", "ct_asw"]
 
     def _fmt(value: float) -> str:
         return "nan" if value != value else f"{value:.4g}"
@@ -409,19 +488,26 @@ def format_results_table(results: Sequence[BenchmarkResult]) -> str:
     rows: List[List[str]] = []
     for result in results:
         cfg = result.config
-        rows.append(
-            [
-                cfg.name,
-                cfg.likelihood,
-                f"{cfg.n_codebooks}x{cfg.codebook_size}",
-                _fmt(result.train_loss),
-                _fmt(result.eval.reconstruction.nll),
-                _fmt(result.eval.reconstruction.mae),
-                _fmt(result.eval.codebook.perplexity),
-                _fmt(result.eval.codebook.utilization),
-                _fmt(result.eval.separability),
+        row = [
+            cfg.name,
+            cfg.likelihood,
+            f"{cfg.n_codebooks}x{cfg.codebook_size}",
+            _fmt(result.train_loss),
+            _fmt(result.eval.reconstruction.nll),
+            _fmt(result.eval.reconstruction.mae),
+            _fmt(result.eval.codebook.perplexity),
+            _fmt(result.eval.codebook.utilization),
+            _fmt(result.eval.separability),
+            _fmt(result.eval.separability_quantized),
+            _fmt(result.eval.separability_gap),
+        ]
+        if show_clustering:
+            row += [
+                _fmt(result.eval.nmi),
+                _fmt(result.eval.ari),
+                _fmt(result.eval.cell_type_asw),
             ]
-        )
+        rows.append(row)
 
     widths = [
         max(len(headers[col]), *(len(row[col]) for row in rows))

--- a/src/omvqvae/benchmark/viz.py
+++ b/src/omvqvae/benchmark/viz.py
@@ -50,6 +50,7 @@ def compute_umap(
     n_neighbors: int = 15,
     min_dist: float = 0.1,
     random_state: int = 0,
+    jitter: float = 0.0,
 ) -> np.ndarray:
     """
     Project a latent space to 2-D with UMAP.
@@ -63,7 +64,17 @@ def compute_umap(
     min_dist : float, default 0.1
         UMAP minimum-distance packing parameter.
     random_state : int, default 0
-        Seed for a deterministic embedding.
+        Seed for a deterministic embedding (and for the jitter noise).
+    jitter : float, default 0.0
+        Standard deviation of optional Gaussian noise added before embedding,
+        **as a fraction of the mean per-dimension standard deviation** of the
+        data. Use a small value (e.g. ``0.02``) for a *discrete* latent such as
+        the post-quantization representation: identical codes produce exactly
+        coincident rows, whose zero-distance ties make UMAP's spectral
+        initialization fail ("too small an eigengap" → random init → a
+        scattered, structure-less layout). A touch of jitter breaks the ties so
+        the global layout is recovered, without meaningfully moving points. No-op
+        at ``0.0``.
 
     Returns
     -------
@@ -75,7 +86,7 @@ def compute_umap(
     ImportError
         If ``umap-learn`` is not installed.
     ValueError
-        If ``latent`` is not 2-D.
+        If ``latent`` is not 2-D or ``jitter`` is negative.
     """
     try:
         import umap
@@ -85,11 +96,27 @@ def compute_umap(
     array = np.asarray(_to_numpy(latent), dtype=np.float32)
     if array.ndim != 2:
         raise ValueError(f"latent must be 2-D (n_cells, n_latent); got {array.ndim}-D.")
+    array = _apply_jitter(array, jitter, random_state)
     reducer = umap.UMAP(
         n_neighbors=n_neighbors, min_dist=min_dist, random_state=random_state
     )
     coords: np.ndarray = reducer.fit_transform(array)
     return coords
+
+
+def _apply_jitter(array: np.ndarray, jitter: float, random_state: int) -> np.ndarray:
+    """Add Gaussian noise scaled to the data's spread (tie-breaking for UMAP)."""
+    if jitter < 0.0:
+        raise ValueError(f"jitter must be non-negative; got {jitter}.")
+    if jitter == 0.0:
+        return array
+    scale = float(np.mean(array.std(axis=0))) * jitter
+    if scale <= 0.0:  # degenerate (constant) latent — nothing to break up
+        return array
+    rng = np.random.default_rng(random_state)
+    noise = rng.normal(scale=scale, size=array.shape).astype(array.dtype)
+    jittered: np.ndarray = array + noise
+    return jittered
 
 
 def plot_latent_umap(
@@ -103,6 +130,8 @@ def plot_latent_umap(
     min_dist: float = 0.1,
     random_state: int = 0,
     point_size: float = 6.0,
+    jitter: float = 0.0,
+    quantized_jitter: float = 0.02,
 ) -> "Figure":
     """
     UMAP-embed a latent and scatter it, coloured by categorical annotations.
@@ -131,6 +160,15 @@ def plot_latent_umap(
         Forwarded to :func:`compute_umap`.
     point_size : float, default 6.0
         Scatter marker size.
+    jitter : float, default 0.0
+        Jitter applied to the **continuous** ``latent`` row (see
+        :func:`compute_umap`); usually unnecessary and left at ``0``.
+    quantized_jitter : float, default 0.02
+        Jitter applied to the **quantized** row. The post-quantization latent is
+        discrete — cells sharing codes are exactly coincident — which makes UMAP's
+        spectral init fail and scatter the points; a small default jitter breaks
+        those ties so the quantized panel shows the same structure the near-zero
+        separability gap implies. Set to ``0`` to disable.
 
     Returns
     -------
@@ -160,9 +198,11 @@ def plot_latent_umap(
     if not colorings:
         colorings.append(("cells", [0] * n_cells))
 
-    rows: List[Tuple[str, "LatentLike"]] = [("latent", latent)]
+    # Each row carries its own jitter: the discrete quantized latent needs a
+    # touch to break exact-duplicate ties, the continuous latent usually does not.
+    rows: List[Tuple[str, "LatentLike", float]] = [("latent", latent, jitter)]
     if quantized is not None:
-        rows.append(("quantized", quantized))
+        rows.append(("quantized", quantized, quantized_jitter))
 
     n_rows, n_cols = len(rows), len(colorings)
     fig, axes = plt.subplots(
@@ -171,12 +211,13 @@ def plot_latent_umap(
         figsize=(5.0 * n_cols, 4.5 * n_rows),
         squeeze=False,
     )
-    for r, (row_name, rep) in enumerate(rows):
+    for r, (row_name, rep, row_jitter) in enumerate(rows):
         coords = compute_umap(
             rep,
             n_neighbors=n_neighbors,
             min_dist=min_dist,
             random_state=random_state,
+            jitter=row_jitter,
         )
         for c, (col_name, groups) in enumerate(colorings):
             ax = axes[r][c]

--- a/src/omvqvae/benchmark/viz.py
+++ b/src/omvqvae/benchmark/viz.py
@@ -1,0 +1,226 @@
+"""
+UMAP visualization of an OQAE latent space.
+
+A qualitative companion to the quantitative benchmark metrics: project a latent
+onto 2-D with UMAP and colour the cells by a categorical annotation (cell type,
+donor, assay, …) to eyeball whether biologically distinct cells separate and
+whether obvious batch structure dominates.
+
+The discrete VQ bottleneck is **not** an obstacle: OQAE exposes two continuous
+representations that UMAP handles directly — the pre-quantization latent
+(:attr:`omvqvae.inference.EncodedCells.latent`) and the post-quantization latent
+(``.quantized``, the codes embedded back into latent space). Plotting both side
+by side (``quantized=`` below) visualizes the quantization cost measured by the
+separability gap. Do **not** UMAP the raw integer codes: Euclidean distance
+between codebook *indices* is meaningless (index 5 is not "closer" to 6 than to
+500); one-hot + Hamming distance would be required and is out of scope here.
+
+Requires the optional ``benchmark`` extra (``umap-learn`` + ``matplotlib``);
+both are **lazy-imported** so ``import omvqvae`` stays light.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List, Optional, Sequence, Tuple
+
+import numpy as np
+
+from omvqvae.utils.logging import get_logger
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from matplotlib.axes import Axes
+    from matplotlib.figure import Figure
+
+    from omvqvae.benchmark.metrics import LatentLike
+
+logger = get_logger(__name__)
+
+__all__ = ["compute_umap", "plot_latent_umap"]
+
+_MISSING_DEP_MSG = (
+    "plot_latent_umap requires the optional 'umap-learn' and 'matplotlib' "
+    "dependencies. Install the benchmark extra, e.g. `uv sync --extra benchmark` "
+    "or `pip install 'oqae[benchmark]'`."
+)
+
+
+def compute_umap(
+    latent: "LatentLike",
+    *,
+    n_neighbors: int = 15,
+    min_dist: float = 0.1,
+    random_state: int = 0,
+) -> np.ndarray:
+    """
+    Project a latent space to 2-D with UMAP.
+
+    Parameters
+    ----------
+    latent : numpy.ndarray or torch.Tensor
+        Latent vectors of shape ``(n_cells, n_latent)``.
+    n_neighbors : int, default 15
+        UMAP neighbourhood size.
+    min_dist : float, default 0.1
+        UMAP minimum-distance packing parameter.
+    random_state : int, default 0
+        Seed for a deterministic embedding.
+
+    Returns
+    -------
+    numpy.ndarray
+        2-D coordinates of shape ``(n_cells, 2)``.
+
+    Raises
+    ------
+    ImportError
+        If ``umap-learn`` is not installed.
+    ValueError
+        If ``latent`` is not 2-D.
+    """
+    try:
+        import umap
+    except ImportError as exc:  # pragma: no cover - exercised only without the dep
+        raise ImportError(_MISSING_DEP_MSG) from exc
+
+    array = np.asarray(_to_numpy(latent), dtype=np.float32)
+    if array.ndim != 2:
+        raise ValueError(f"latent must be 2-D (n_cells, n_latent); got {array.ndim}-D.")
+    reducer = umap.UMAP(
+        n_neighbors=n_neighbors, min_dist=min_dist, random_state=random_state
+    )
+    coords: np.ndarray = reducer.fit_transform(array)
+    return coords
+
+
+def plot_latent_umap(
+    latent: "LatentLike",
+    labels: Optional[Sequence[object]] = None,
+    *,
+    color_by: Optional[Sequence[object]] = None,
+    color_by_name: str = "batch",
+    quantized: Optional["LatentLike"] = None,
+    n_neighbors: int = 15,
+    min_dist: float = 0.1,
+    random_state: int = 0,
+    point_size: float = 6.0,
+) -> "Figure":
+    """
+    UMAP-embed a latent and scatter it, coloured by categorical annotations.
+
+    One column is drawn per colouring (``labels`` and, if given, ``color_by``);
+    one row per representation (the continuous ``latent`` and, if given,
+    ``quantized``). The same UMAP coordinates back every colouring within a row.
+
+    Parameters
+    ----------
+    latent : numpy.ndarray or torch.Tensor
+        Continuous latent of shape ``(n_cells, n_latent)`` (the primary panel).
+    labels : Sequence, optional
+        Per-cell categorical annotation for the first colouring (e.g. cell type).
+        A single unlabelled panel is drawn when omitted.
+    color_by : Sequence, optional
+        A second per-cell annotation (e.g. donor / assay) drawn as an additional
+        column — the "batch view".
+    color_by_name : str, default "batch"
+        Title/legend name for the ``color_by`` column.
+    quantized : numpy.ndarray or torch.Tensor, optional
+        Post-quantization latent (:attr:`omvqvae.inference.EncodedCells.quantized`)
+        of shape ``(n_cells, n_latent)``; drawn as a second row to visualize the
+        quantization cost.
+    n_neighbors, min_dist, random_state : UMAP parameters
+        Forwarded to :func:`compute_umap`.
+    point_size : float, default 6.0
+        Scatter marker size.
+
+    Returns
+    -------
+    matplotlib.figure.Figure
+        The assembled figure (not shown or saved; the caller decides).
+
+    Raises
+    ------
+    ImportError
+        If ``umap-learn`` / ``matplotlib`` are not installed.
+    ValueError
+        If any provided annotation length disagrees with the number of cells.
+    """
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError as exc:  # pragma: no cover - exercised only without the dep
+        raise ImportError(_MISSING_DEP_MSG) from exc
+
+    n_cells = np.asarray(_to_numpy(latent)).shape[0]
+    colorings: List[Tuple[str, Sequence[object]]] = []
+    if labels is not None:
+        _check_length(labels, n_cells, "labels")
+        colorings.append(("cell type", labels))
+    if color_by is not None:
+        _check_length(color_by, n_cells, "color_by")
+        colorings.append((color_by_name, color_by))
+    if not colorings:
+        colorings.append(("cells", [0] * n_cells))
+
+    rows: List[Tuple[str, "LatentLike"]] = [("latent", latent)]
+    if quantized is not None:
+        rows.append(("quantized", quantized))
+
+    n_rows, n_cols = len(rows), len(colorings)
+    fig, axes = plt.subplots(
+        n_rows,
+        n_cols,
+        figsize=(5.0 * n_cols, 4.5 * n_rows),
+        squeeze=False,
+    )
+    for r, (row_name, rep) in enumerate(rows):
+        coords = compute_umap(
+            rep,
+            n_neighbors=n_neighbors,
+            min_dist=min_dist,
+            random_state=random_state,
+        )
+        for c, (col_name, groups) in enumerate(colorings):
+            ax = axes[r][c]
+            _scatter_by_group(ax, coords, groups, point_size=point_size)
+            ax.set_title(f"{row_name} — {col_name}")
+            ax.set_xticks([])
+            ax.set_yticks([])
+    fig.tight_layout()
+    return fig
+
+
+def _scatter_by_group(
+    ax: "Axes",
+    coords: np.ndarray,
+    groups: Sequence[object],
+    *,
+    point_size: float,
+) -> None:
+    """Scatter ``coords`` with one colour per distinct value in ``groups``."""
+    groups_arr = np.asarray(list(groups), dtype=object)
+    unique = np.unique(groups_arr)
+    for value in unique:
+        mask = groups_arr == value
+        ax.scatter(
+            coords[mask, 0],
+            coords[mask, 1],
+            s=point_size,
+            label=str(value),
+            linewidths=0.0,
+        )
+    # Only show a legend when it stays readable.
+    if 1 < unique.size <= 20:
+        ax.legend(markerscale=2.0, fontsize="x-small", loc="best", frameon=False)
+
+
+def _check_length(values: Sequence[object], n_cells: int, name: str) -> None:
+    """Raise if ``values`` does not have exactly ``n_cells`` entries."""
+    length = len(list(values))
+    if length != n_cells:
+        raise ValueError(f"{name} has length {length} but there are {n_cells} cells.")
+
+
+def _to_numpy(latent: "LatentLike") -> np.ndarray:
+    """Coerce a latent array-like to a NumPy array without importing torch."""
+    if hasattr(latent, "detach"):  # torch.Tensor without importing torch here
+        return latent.detach().cpu().numpy()
+    return np.asarray(latent)

--- a/src/omvqvae/inference/codes.py
+++ b/src/omvqvae/inference/codes.py
@@ -89,11 +89,19 @@ class EncodedCells:
         The continuous pre-quantization latent of shape ``(n_cells, n_latent)``
         (``float32``); useful for inspecting quantization error but not required
         for decoding.
+    quantized : torch.Tensor
+        The continuous *post*-quantization latent of shape
+        ``(n_cells, n_latent)`` (``float32``) — the sum of the per-level codebook
+        vectors selected by ``codes``. This is the model's discrete
+        representation embedded back into latent space; comparing metrics on
+        ``latent`` vs ``quantized`` quantifies how much the codebook bottleneck
+        costs.
     """
 
     codes: Tensor
     size_factors: Tensor
     latent: Tensor
+    quantized: Tensor
 
     def __len__(self) -> int:
         return int(self.codes.shape[0])
@@ -195,15 +203,20 @@ def encode(
     counts_t = torch.from_numpy(np.ascontiguousarray(dense, dtype=np.float32))
     codes = torch.empty((n_cells, model.n_codebooks), dtype=torch.long)
     latent = torch.empty((n_cells, model.n_latent), dtype=torch.float32)
+    quantized = torch.empty((n_cells, model.n_latent), dtype=torch.float32)
 
     with _inference_mode(model):
         for start in range(0, n_cells, batch_size):
             stop = min(start + batch_size, n_cells)
             z = model.encode(counts_t[start:stop])
-            codes[start:stop] = model.quantize(z).indices
+            rvq = model.quantize(z)
+            codes[start:stop] = rvq.indices
             latent[start:stop] = z
+            quantized[start:stop] = rvq.quantized
 
-    return EncodedCells(codes=codes, size_factors=factors, latent=latent)
+    return EncodedCells(
+        codes=codes, size_factors=factors, latent=latent, quantized=quantized
+    )
 
 
 def encode_anndata(

--- a/tests/benchmark/test_clustering.py
+++ b/tests/benchmark/test_clustering.py
@@ -1,0 +1,72 @@
+"""Tests for :mod:`omvqvae.benchmark.clustering` (NMI / ARI / cell-type ASW).
+
+The clustering metrics require the optional ``scib-metrics`` dependency, so the
+substantive tests are guarded with :func:`pytest.importorskip` and skip cleanly
+on an offline default install.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from omvqvae.benchmark.clustering import ClusteringMetrics, clustering_metrics
+
+scib_metrics = pytest.importorskip("scib_metrics")
+
+
+def _two_blobs(sep: float = 6.0, seed: int = 0) -> tuple[np.ndarray, np.ndarray]:
+    """Two well-separated Gaussian blobs with matching labels."""
+    rng = np.random.default_rng(seed)
+    a = rng.normal(0.0, 0.15, size=(40, 8))
+    b = rng.normal(sep, 0.15, size=(40, 8))
+    latent = np.vstack([a, b]).astype(np.float32)
+    labels = np.array(["A"] * 40 + ["B"] * 40, dtype=object)
+    return latent, labels
+
+
+def test_clustering_metrics_recovers_clean_clusters() -> None:
+    """Well-separated blocks matching their labels score near 1."""
+    latent, labels = _two_blobs()
+    metrics = clustering_metrics(latent, labels)
+    assert isinstance(metrics, ClusteringMetrics)
+    assert metrics.nmi > 0.9
+    assert metrics.ari > 0.9
+    assert metrics.cell_type_asw > 0.7
+
+
+def test_clustering_metrics_low_for_shuffled_labels() -> None:
+    """Labels unrelated to the geometry score near chance (low NMI/ARI)."""
+    latent, labels = _two_blobs()
+    rng = np.random.default_rng(1)
+    shuffled = labels.copy()
+    rng.shuffle(shuffled)
+    metrics = clustering_metrics(latent, shuffled)
+    assert metrics.nmi < 0.5
+    assert metrics.ari < 0.5
+
+
+def test_clustering_metrics_single_label_is_nan() -> None:
+    """Fewer than two distinct labels leaves the metrics undefined (nan)."""
+    latent, _ = _two_blobs()
+    metrics = clustering_metrics(latent, ["only"] * latent.shape[0])
+    assert math.isnan(metrics.nmi)
+    assert math.isnan(metrics.ari)
+    assert math.isnan(metrics.cell_type_asw)
+
+
+def test_clustering_metrics_length_mismatch_raises() -> None:
+    """A labels/cells length mismatch is a clear ValueError."""
+    latent, labels = _two_blobs()
+    with pytest.raises(ValueError, match="labels has length"):
+        clustering_metrics(latent, labels[:-1])
+
+
+def test_clustering_metrics_accepts_torch_tensor() -> None:
+    """A torch latent is coerced without a hard torch import in the module."""
+    torch = pytest.importorskip("torch")
+    latent, labels = _two_blobs()
+    metrics = clustering_metrics(torch.from_numpy(latent), labels)
+    assert metrics.nmi > 0.9

--- a/tests/benchmark/test_harness.py
+++ b/tests/benchmark/test_harness.py
@@ -67,6 +67,11 @@ def test_evaluate_model_returns_all_metrics() -> None:
     assert math.isfinite(metrics.reconstruction.nll)
     assert 0.0 <= metrics.codebook.utilization <= 1.0
     assert 0.0 <= metrics.separability <= 1.0
+    assert 0.0 <= metrics.separability_quantized <= 1.0
+    assert math.isclose(
+        metrics.separability_gap,
+        metrics.separability - metrics.separability_quantized,
+    )
     assert metrics.codebook.codebook_size == 16
 
 
@@ -76,6 +81,34 @@ def test_evaluate_model_without_labels_has_nan_separability() -> None:
     model = OmicsVQVAE(N_GENES, n_latent=8, hidden_dims=(16,))
     metrics = evaluate_model(model, counts)
     assert math.isnan(metrics.separability)
+    assert math.isnan(metrics.separability_quantized)
+    assert math.isnan(metrics.separability_gap)
+
+
+def test_evaluate_model_clustering_off_by_default() -> None:
+    """NMI/ARI/ASW stay nan unless clustering is explicitly requested."""
+    counts, labels = _synthetic_counts()
+    model = OmicsVQVAE(N_GENES, n_latent=8, hidden_dims=(16,), codebook_size=16)
+    metrics = evaluate_model(model, counts, eval_labels=labels)
+    assert math.isnan(metrics.nmi)
+    assert math.isnan(metrics.ari)
+    assert math.isnan(metrics.cell_type_asw)
+
+
+def test_evaluate_model_with_clustering_opt_in() -> None:
+    """``compute_clustering=True`` populates the scIB metrics (needs scib-metrics)."""
+    pytest.importorskip("scib_metrics")
+    counts, labels = _synthetic_counts()
+    model = OmicsVQVAE(N_GENES, n_latent=8, hidden_dims=(16,), codebook_size=16)
+    metrics = evaluate_model(model, counts, eval_labels=labels, compute_clustering=True)
+    assert 0.0 <= metrics.nmi <= 1.0
+    assert not math.isnan(metrics.ari)
+    assert 0.0 <= metrics.cell_type_asw <= 1.0
+    # The clustering columns surface in the table only when computed.
+    result = BenchmarkResult(
+        config=BenchmarkConfig(name="c"), train_loss=1.0, eval=metrics
+    )
+    assert "nmi" in format_results_table([result])
 
 
 def test_run_benchmark_trains_and_evaluates() -> None:
@@ -158,10 +191,14 @@ def test_run_suite_and_reporting() -> None:
     assert len(rows) == 3
     assert rows[0]["likelihood"] == "nb"
     assert "perplexity" in rows[0]
+    assert "separability_quantized" in rows[0]
+    assert "separability_gap" in rows[0]
 
     table = format_results_table(results)
     assert table.startswith("| name")
     assert "gaussian" in table
+    # Clustering was not requested, so those columns are omitted.
+    assert "nmi" not in table
     # One header, one separator, three data rows.
     assert len(table.splitlines()) == 5
 

--- a/tests/benchmark/test_viz.py
+++ b/tests/benchmark/test_viz.py
@@ -1,0 +1,60 @@
+"""Tests for :mod:`omvqvae.benchmark.viz` (UMAP latent visualization).
+
+Guarded with :func:`pytest.importorskip` on ``umap`` / ``matplotlib`` so they
+skip cleanly when the optional ``benchmark`` extra is absent.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pytest.importorskip("umap")
+pytest.importorskip("matplotlib")
+
+from omvqvae.benchmark.viz import compute_umap, plot_latent_umap  # noqa: E402
+
+
+def _latent(n: int = 40, seed: int = 0) -> tuple[np.ndarray, np.ndarray]:
+    rng = np.random.default_rng(seed)
+    a = rng.normal(0.0, 0.2, size=(n // 2, 8))
+    b = rng.normal(4.0, 0.2, size=(n // 2, 8))
+    latent = np.vstack([a, b]).astype(np.float32)
+    labels = np.array(["A"] * (n // 2) + ["B"] * (n // 2), dtype=object)
+    return latent, labels
+
+
+def test_compute_umap_shape() -> None:
+    latent, _ = _latent()
+    coords = compute_umap(latent, n_neighbors=5, random_state=0)
+    assert coords.shape == (latent.shape[0], 2)
+
+
+def test_plot_latent_umap_single_panel() -> None:
+    latent, labels = _latent()
+    fig = plot_latent_umap(latent, labels, n_neighbors=5)
+    # One row (latent), one column (cell type).
+    assert len(fig.axes) == 1
+    # Scatter drew both label groups (one PathCollection each).
+    assert len(fig.axes[0].collections) == 2
+
+
+def test_plot_latent_umap_grid_with_batch_and_quantized() -> None:
+    """labels + color_by (cols) × latent + quantized (rows) → a 2x2 grid."""
+    latent, labels = _latent()
+    quantized = latent + 0.01
+    batch = np.array(["x", "y"] * (latent.shape[0] // 2), dtype=object)
+    fig = plot_latent_umap(
+        latent,
+        labels,
+        color_by=batch,
+        quantized=quantized,
+        n_neighbors=5,
+    )
+    assert len(fig.axes) == 4
+
+
+def test_plot_latent_umap_length_mismatch_raises() -> None:
+    latent, labels = _latent()
+    with pytest.raises(ValueError, match="labels has length"):
+        plot_latent_umap(latent, labels[:-1], n_neighbors=5)

--- a/tests/benchmark/test_viz.py
+++ b/tests/benchmark/test_viz.py
@@ -58,3 +58,30 @@ def test_plot_latent_umap_length_mismatch_raises() -> None:
     latent, labels = _latent()
     with pytest.raises(ValueError, match="labels has length"):
         plot_latent_umap(latent, labels[:-1], n_neighbors=5)
+
+
+def test_compute_umap_jitter_breaks_duplicate_ties() -> None:
+    """Jitter de-duplicates a discrete (quantized-like) latent for UMAP."""
+    rng = np.random.default_rng(0)
+    codebook = rng.normal(size=(6, 8))
+    assign = rng.integers(0, 6, size=60)
+    quantized = codebook[assign].astype(np.float32)  # only 6 distinct rows
+    # Without jitter UMAP still runs, but the input is massively degenerate.
+    coords = compute_umap(quantized, n_neighbors=5, jitter=0.05)
+    assert coords.shape == (60, 2)
+    assert np.isfinite(coords).all()
+
+
+def test_compute_umap_jitter_zero_is_noop() -> None:
+    """``jitter=0`` leaves the data untouched (deterministic embedding)."""
+    from omvqvae.benchmark.viz import _apply_jitter
+
+    latent, _ = _latent()
+    same = _apply_jitter(latent, 0.0, 0)
+    assert np.array_equal(same, latent)
+
+
+def test_compute_umap_negative_jitter_raises() -> None:
+    latent, _ = _latent()
+    with pytest.raises(ValueError, match="jitter must be non-negative"):
+        compute_umap(latent, n_neighbors=5, jitter=-0.1)

--- a/tests/inference/test_codes.py
+++ b/tests/inference/test_codes.py
@@ -111,6 +111,8 @@ def test_encode_shapes_and_dtypes() -> None:
     assert enc.codes.dtype == torch.long
     assert enc.size_factors.shape == (7,)
     assert enc.latent.shape == (7, model.n_latent)
+    assert enc.quantized.shape == (7, model.n_latent)
+    assert enc.quantized.dtype == torch.float32
     assert len(enc) == 7
     # Default size factors are the per-cell totals ("total" mode).
     assert torch.allclose(enc.size_factors, counts.sum(dim=1))
@@ -125,6 +127,17 @@ def test_encode_matches_model_encode_codes() -> None:
     assert torch.equal(enc.codes, expected)
 
 
+def test_encode_quantized_matches_model_quantize() -> None:
+    """``EncodedCells.quantized`` is the post-quantization latent for the codes."""
+    model = _model()
+    counts = _counts()
+    model.eval()
+    with torch.no_grad():
+        expected = model.quantize(model.encode(counts)).quantized
+    enc = encode(model, counts)
+    assert torch.allclose(enc.quantized, expected, atol=1e-6)
+
+
 def test_encode_batched_equals_unbatched() -> None:
     model = _model()
     counts = _counts(n_cells=10)
@@ -132,6 +145,7 @@ def test_encode_batched_equals_unbatched() -> None:
     chunked = encode(model, counts, batch_size=3)
     assert torch.equal(full.codes, chunked.codes)
     assert torch.allclose(full.latent, chunked.latent, atol=1e-6)
+    assert torch.allclose(full.quantized, chunked.quantized, atol=1e-6)
 
 
 def test_encode_accepts_numpy_and_sparse() -> None:

--- a/tests/test_benchmark_report.py
+++ b/tests/test_benchmark_report.py
@@ -146,6 +146,8 @@ def _result(
                 codebook_size=16,
             ),
             separability=separability,
+            separability_quantized=separability,
+            separability_gap=0.0,
         ),
     )
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -89,6 +89,27 @@ def test_example_05_writes_report(tmp_path: Path) -> None:
     assert out.read_text(encoding="utf-8").startswith("# OQAE benchmark report")
 
 
+def test_example_07_latent_quality() -> None:
+    """Example 7 runs the quality metrics + UMAP (needs the benchmark extra)."""
+    pytest.importorskip("scib_metrics")
+    pytest.importorskip("umap")
+    module = _load_example("07_latent_quality.py")
+    table, fig = module.main(compute_clustering=True, make_umap=True)
+    assert table.startswith("| name")
+    # Clustering was requested, so the scIB columns are present.
+    assert "nmi" in table
+    assert fig is not None
+
+
+def test_example_07_latent_quality_core_only() -> None:
+    """Example 7 also runs without the optional metrics (core install path)."""
+    module = _load_example("07_latent_quality.py")
+    table, fig = module.main(compute_clustering=False, make_umap=False)
+    assert table.startswith("| name")
+    assert "nmi" not in table
+    assert fig is None
+
+
 def test_example_03_imports() -> None:
     """The Census example imports cleanly (its ``main`` is network-gated)."""
     module = _load_example("03_census_streaming.py")

--- a/uv.lock
+++ b/uv.lock
@@ -3,8 +3,18 @@ revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version >= '3.12' and python_full_version < '3.15'",
+    "python_full_version >= '3.13' and python_full_version < '3.15'",
+    "python_full_version == '3.12.*'",
     "python_full_version < '3.12'",
+]
+
+[[package]]
+name = "absl-py"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/c7/8de93764ad66968d19329a7e0c147a2bb3c7054c554d4a119111b8f9440f/absl_py-2.4.0.tar.gz", hash = "sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4", size = 116543, upload-time = "2026-01-28T10:17:05.322Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/a6/907a406bb7d359e6a63f99c313846d9eec4f7e6f7437809e03aa00fa3074/absl_py-2.4.0-py3-none-any.whl", hash = "sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d", size = 135750, upload-time = "2026-01-28T10:17:04.19Z" },
 ]
 
 [[package]]
@@ -520,6 +530,23 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
     { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
     { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
+name = "chex"
+version = "0.1.92"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py" },
+    { name = "jax" },
+    { name = "jaxlib" },
+    { name = "numpy" },
+    { name = "toolz" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/71/7b2c28cd5ba2743e7cd4d1262d73cdc83c3dce395f56fd52c0ff50947514/chex-0.1.92.tar.gz", hash = "sha256:fa8beff1124204ae466a6eb13cb91ae3c24322a1c7216946aee93d031e2f1996", size = 91863, upload-time = "2026-06-12T14:28:37.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/42/5d8282d6dc4cd9971f865eb5cc767d180d1564475826e43150d1ea1dba51/chex-0.1.92-py3-none-any.whl", hash = "sha256:f34989d9bff7954edfab09fba7757e3d62404da34577bff0d253599ec5b4f93d", size = 102275, upload-time = "2026-06-12T14:28:36.579Z" },
 ]
 
 [[package]]
@@ -1273,6 +1300,31 @@ wheels = [
 ]
 
 [[package]]
+name = "igraph"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "texttable" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/23/be/56bef1919005b4caf1f71522b300d359f7faeb7ae93a3b0baa9b4f146a87/igraph-1.0.0.tar.gz", hash = "sha256:2414d0be2e4d77ee5357807d100974b40f6082bb1bb71988ec46cfb6728651ee", size = 5077105, upload-time = "2025-10-23T12:22:50.127Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/03/3278ad0ceb3ea0e84d8ae3a85bdded4d0e57853aeb802a200feb43847b93/igraph-1.0.0-cp39-abi3-macosx_10_15_x86_64.whl", hash = "sha256:c2cbc415e02523e5a241eecee82319080bf928a70b1ba299f3b3e25bf029b6d4", size = 2257415, upload-time = "2025-10-23T12:22:27.246Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bc/6281ec7f9baaf71ee57c3b1748da2d3148d15d253e1a03006f204aa68ca5/igraph-1.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a27753cd80680a8f676c2d5a467aaa4a95e510b30748398ec4e4aeb982130e8", size = 2048555, upload-time = "2025-10-23T12:22:29.49Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/38/3cd6428a4ed4c09a56df05998438e7774fd1d799ee4fb8fc481674f5f7fc/igraph-1.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a55dc3a2a4e3fc3eba42479910c1511bfc3ecb33cdf5f0406891fd85f14b5aee", size = 5314141, upload-time = "2025-10-23T12:22:31.023Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/da/dd2867c25adbb41563720f14b5fc895c98bf88be682a3faff4f7b3118d2a/igraph-1.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2d04c2c76f686fb1f554ee35dfd3085f5e73b7965ba6b4cf06d53e66b1955522", size = 5683134, upload-time = "2025-10-23T12:22:32.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/40/243c118d34ab80382d7009c4dcb99b887384c3d2ce84d29eeac19e2a007a/igraph-1.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:f2b52dc1757fff0fed29a9f7a276d971a11db4211569ed78b9eab36288dfcc9d", size = 6211583, upload-time = "2025-10-23T12:22:34.238Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/b7/88f433819c54b496cb0315fce28e658970cb20ff5dbd52a5a605ce2888de/igraph-1.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:05c79a2a8fca695b2f217a6fa7f2549f896f757d4db41be32a055400cb19cc30", size = 6594509, upload-time = "2025-10-23T12:22:35.831Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5d/8f7f6f619d374e959aa3664ebc4b24c10abc90c2e8efbed97f2623fadaf5/igraph-1.0.0-cp39-abi3-win32.whl", hash = "sha256:c2bce3cd472fec3dd9c4d8a3ea5b6b9be65fb30edf760beb4850760dd4f2d479", size = 2725406, upload-time = "2025-10-23T12:22:37.588Z" },
+    { url = "https://files.pythonhosted.org/packages/af/77/a85b3745cf40a0572bae2de8cd9c2a2a8af78e5cf3e880fc0a249114e609/igraph-1.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:faeff8ede0cf15eb4ded44b0fcea6e1886740146e60504c24ad2da14e0939563", size = 3221663, upload-time = "2025-10-23T12:22:39.404Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/7e/5df541c37bdf6493035e89c22bd53f30d99b291bcda6c78e9a8afeecec2b/igraph-1.0.0-cp39-abi3-win_arm64.whl", hash = "sha256:b607cafc24b10a615e713ee96e58208ef27e0764af80140c7cc45d4724a3f2df", size = 2785701, upload-time = "2025-10-23T12:22:41.03Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/73/bf1d4dbbc9123435b3ca14bb608b243a50a4f158ecea564bf196715248d9/igraph-1.0.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:3189c1a8e8a8f58009f3f729040eb3701254d074ed37245691d529869ec940c5", size = 2246636, upload-time = "2025-10-23T12:22:42.314Z" },
+    { url = "https://files.pythonhosted.org/packages/59/ac/28482f2af45cc0a0ca88a69d17a6ea694f58bdbd22cc876e7273a0379282/igraph-1.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ebe9502689b946301584b3cfacdbc70c58c4d664d804e39b6daa31be5c20bf46", size = 2036101, upload-time = "2025-10-23T12:22:43.957Z" },
+    { url = "https://files.pythonhosted.org/packages/56/80/806a093df1d1ddc3b30d0418b1ee56388ae7018f8ae288677ee2b3a1abaf/igraph-1.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:f117683108c54330d6dc67a708e3724c13c9989885122a29781296872989a222", size = 3053403, upload-time = "2025-10-23T12:22:45.573Z" },
+    { url = "https://files.pythonhosted.org/packages/56/bf/cf7aeff230a4368c0b8bc6b02f3ea27db41db33714b51e1e8a7c1458f31b/igraph-1.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:077dbff0edb8b4ce0f9fefdf325200346d9d5db02de31872b41743de08e67a16", size = 3262472, upload-time = "2025-10-23T12:22:47.248Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/ca/dbc06072d5eea402a6dc81f387afb1b7e0c415f1d8a75232943fc4d1bfdb/igraph-1.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:fe7c693b2a84a4e03ca31e65aa05a2ecd8728137fa9909ccbf6453b4200b856d", size = 3218861, upload-time = "2025-10-23T12:22:48.46Z" },
+]
+
+[[package]]
 name = "imagesize"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1297,6 +1349,56 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ef/7c/ec4ab396d31b3b395e2e999c8f46dec78c5e29209fac49d1f4dace04041d/isort-8.0.1.tar.gz", hash = "sha256:171ac4ff559cdc060bcfff550bc8404a486fee0caab245679c2abe7cb253c78d", size = 769592, upload-time = "2026-02-28T10:08:20.685Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3e/95/c7c34aa53c16353c56d0b802fba48d5f5caa2cdee7958acbcb795c830416/isort-8.0.1-py3-none-any.whl", hash = "sha256:28b89bc70f751b559aeca209e6120393d43fbe2490de0559662be7a9787e3d75", size = 89733, upload-time = "2026-02-28T10:08:19.466Z" },
+]
+
+[[package]]
+name = "jax"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jaxlib" },
+    { name = "ml-dtypes" },
+    { name = "numpy" },
+    { name = "opt-einsum" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/73/eb91d98fcadfa2cbcfdd4e417ab116e47eb20882acc5ee678e47c35d6b57/jax-0.10.2.tar.gz", hash = "sha256:bf77428a8c2e6904c4f46d5ab12aa5cfc6cad2179f07f7e4c0fc75ac86ef0639", size = 2775110, upload-time = "2026-06-17T23:44:57.818Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/82/5ab5211079a151b6f661529369c0c8e98ec64cabf5c0cf22a0a05af124d8/jax-0.10.2-py3-none-any.whl", hash = "sha256:724d73c4678d8b06f6a6ab4db1b8a2fea8cd4f1e2c2564f99601634ec7b8d1c6", size = 3219515, upload-time = "2026-06-17T23:42:41.259Z" },
+]
+
+[[package]]
+name = "jaxlib"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ml-dtypes" },
+    { name = "numpy" },
+    { name = "scipy" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/2c/7038fc73154307389631b5b2dbe5ac529e1918eecc19a27e6644ad114bbf/jaxlib-0.10.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5a98873fc867623b81f2bee15d554b8edd6588a183d01fa50d21b1e3db96ff2b", size = 61429039, upload-time = "2026-06-17T23:43:44.858Z" },
+    { url = "https://files.pythonhosted.org/packages/66/c6/d69a0a33046f84930b89387861c061996d5207671b35080898679ca9960a/jaxlib-0.10.2-cp311-cp311-manylinux_2_27_aarch64.whl", hash = "sha256:d44565dcfd1b4f60f76d911c6512118a8a4fc764bdef92663fecb8bfccd54f23", size = 81079180, upload-time = "2026-06-17T23:43:48.245Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/27/fb54e3265c0ffcb687f93e9fb761c589acebbe958c3fed1b2c74c3f0e782/jaxlib-0.10.2-cp311-cp311-manylinux_2_27_x86_64.whl", hash = "sha256:1faca3c5d4662cb4a6130a68105d68bb520764817e165d6eebfd6786c0d1f30f", size = 85448560, upload-time = "2026-06-17T23:43:51.724Z" },
+    { url = "https://files.pythonhosted.org/packages/21/bc/31fbb3d892c3cb97c73af9226eca63d60d8e224017145bdb6871d1d24da6/jaxlib-0.10.2-cp311-cp311-win_amd64.whl", hash = "sha256:e7a9214e6b0b9e0825d905573d1bbf2253c20e9d7464a63e085b60519975553f", size = 65867603, upload-time = "2026-06-17T23:43:54.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/93/ee9cc8743191544f65d26ab7eeb82d65968fe60905662d1a5554d056654b/jaxlib-0.10.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:47bb7c011515ea862be7e8313f40f9c56cbec09dc98a0fcb5016785fcd454c01", size = 61434612, upload-time = "2026-06-17T23:43:57.808Z" },
+    { url = "https://files.pythonhosted.org/packages/11/06/8cc36021bf74d617c312eeed94c280282bb1bcbb32b63f2a42b10ae41575/jaxlib-0.10.2-cp312-cp312-manylinux_2_27_aarch64.whl", hash = "sha256:53b72977ae582c03a9e8e1cdee1efbf8ebc1418270965b0e69eade57acf40331", size = 81085366, upload-time = "2026-06-17T23:44:01.067Z" },
+    { url = "https://files.pythonhosted.org/packages/48/17/38b718af2353dba7753300871e83fbb64a88a772e12727ae27373ab675ce/jaxlib-0.10.2-cp312-cp312-manylinux_2_27_x86_64.whl", hash = "sha256:fe88ec443714c4379968b6c109f9fa617c7ad19b802828e4d7bf861cd66da4b7", size = 85467828, upload-time = "2026-06-17T23:44:04.238Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/c2/d41d13826ebdfe62e56cd87ba70fab3bb9fcbea4a6c9086739a91667e5bf/jaxlib-0.10.2-cp312-cp312-win_amd64.whl", hash = "sha256:4b08f5fbc596b83f76308181863996f93d901d1f09cfd4e130a65c1998e1b371", size = 65900139, upload-time = "2026-06-17T23:44:07.476Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/68/eaa4cebe253359196a8e80a33b242959e27d8d2a6ae3d09339f21da2acb8/jaxlib-0.10.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4df530afa354a22dc1747a5d560640450cbb895d49889338a3f58c76a4c76c8e", size = 61434805, upload-time = "2026-06-17T23:44:10.511Z" },
+    { url = "https://files.pythonhosted.org/packages/25/c1/4b884ea5962b6beb3c0f93742db54246bbf8b3274e48b0aca47908e454be/jaxlib-0.10.2-cp313-cp313-manylinux_2_27_aarch64.whl", hash = "sha256:45b28b0238697ab74bbcf20411aafb6db42acc31836cc2fd711e5cf056bf9556", size = 81084260, upload-time = "2026-06-17T23:44:14.065Z" },
+    { url = "https://files.pythonhosted.org/packages/36/ac/4ee28c65861605945223145fbcd3c9362ec2255ddf7d917574e205548c82/jaxlib-0.10.2-cp313-cp313-manylinux_2_27_x86_64.whl", hash = "sha256:9e4818b4a8756fd3918766ca2aa5342125809f4f08a6fe46026d4386e7c23644", size = 85467706, upload-time = "2026-06-17T23:44:17.471Z" },
+    { url = "https://files.pythonhosted.org/packages/79/54/9918b0f77a25a1299818c0610305ca2bea38ed90584f4489b60357e2dd39/jaxlib-0.10.2-cp313-cp313-win_amd64.whl", hash = "sha256:c75d6f1df1c9cff08e110b4a21c79560fdc502f4288972d6b117d25dafd44352", size = 65897894, upload-time = "2026-06-17T23:44:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5b/70df11da52a8b1a826184cccc05a3fec8aed76058a980021873fba3069cb/jaxlib-0.10.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4c202d8ff7c1f3b5049dbd8f1e30e52759cd4e0a5835f0b3c7ae076a05818e28", size = 61564746, upload-time = "2026-06-17T23:44:24.421Z" },
+    { url = "https://files.pythonhosted.org/packages/23/5c/184a648ea5db6c8b1a08fc5784c157b4c557255e009fb56091393df3c6de/jaxlib-0.10.2-cp313-cp313t-manylinux_2_27_aarch64.whl", hash = "sha256:b7b029bb95d981566750475b9719a9d6b66ed5dd2748851667899b6cfe075299", size = 81204888, upload-time = "2026-06-17T23:44:27.57Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/5c/539596a55265711d74147913278bcdc38412980be7d74d9c9d860297c486/jaxlib-0.10.2-cp313-cp313t-manylinux_2_27_x86_64.whl", hash = "sha256:e8b126097d609b0c6e6786e89f6dd6978adc02ebd5f63a1c61293fbac7821305", size = 85583810, upload-time = "2026-06-17T23:44:30.962Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/0d/27471ec9f1d04674f6e62de809412371e097aed3eca7d9483e677c54c214/jaxlib-0.10.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:72eba28b12fee02616fa42aa4b881b4ab62d7757c7843c462401d3fb34a27be4", size = 61446097, upload-time = "2026-06-17T23:44:34.196Z" },
+    { url = "https://files.pythonhosted.org/packages/af/c8/941a7f7f37510f51290a5bd1a413aeef977fb8ba8adc0cfe8391233a764c/jaxlib-0.10.2-cp314-cp314-manylinux_2_27_aarch64.whl", hash = "sha256:f18f56fee90699cfba9b6627045a7a299702cb0e2af82ce180d9a6a7c8048093", size = 81096546, upload-time = "2026-06-17T23:44:37.486Z" },
+    { url = "https://files.pythonhosted.org/packages/69/77/ac054882c220872512df28d16aeb648fe0e651efbb5be4fd7c4817fd88b0/jaxlib-0.10.2-cp314-cp314-manylinux_2_27_x86_64.whl", hash = "sha256:ca34f363197fb0ac4082582ca755007910369e33f8a8ba3d35ed94b71070107d", size = 85472993, upload-time = "2026-06-17T23:44:40.904Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/7d/c592d1fa69c210be0d2743fffc598dfc2f54efa9671c5f6f5d1e151c6f4a/jaxlib-0.10.2-cp314-cp314-win_amd64.whl", hash = "sha256:99818b0a18adc0b899abf4873795e8d65169441d87ab2e5cbb228e73d0f25808", size = 68376553, upload-time = "2026-06-17T23:44:44.968Z" },
+    { url = "https://files.pythonhosted.org/packages/54/9b/91b00ec74985d29708b50420b4103c1f651c8f1c253d4fcb49d1bbb532cd/jaxlib-0.10.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:fc62997fce8831819551a2a5469a818169b09582b5b648c102d11ac7205bb812", size = 61564620, upload-time = "2026-06-17T23:44:48.217Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/c7/49d2b19c3b3105c30e1d3af2062e82e1977fb239d3dc3cbb583ef676dda7/jaxlib-0.10.2-cp314-cp314t-manylinux_2_27_aarch64.whl", hash = "sha256:a24d6e3cba263978293eae8b41330d5ccf24d6cdd1a6bcd4e82aff34e767620d", size = 81206365, upload-time = "2026-06-17T23:44:51.419Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/99/006cedf443f4a01f2088651facce79b2105bfb4905bfe9162eb0920a6dfb/jaxlib-0.10.2-cp314-cp314t-manylinux_2_27_x86_64.whl", hash = "sha256:5a2ac7aed7c4e661f67600bbcdec9e589151c1efec91f4cdb8d484af1a45c895", size = 85584458, upload-time = "2026-06-17T23:44:55.377Z" },
 ]
 
 [[package]]
@@ -1711,6 +1813,47 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "ml-dtypes"
+version = "0.5.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/4a/c27b42ed9b1c7d13d9ba8b6905dece787d6259152f2309338aed29b2447b/ml_dtypes-0.5.4.tar.gz", hash = "sha256:8ab06a50fb9bf9666dd0fe5dfb4676fa2b0ac0f31ecff72a6c3af8e22c063453", size = 692314, upload-time = "2025-11-17T22:32:31.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/5e/712092cfe7e5eb667b8ad9ca7c54442f21ed7ca8979745f1000e24cf8737/ml_dtypes-0.5.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6c7ecb74c4bd71db68a6bea1edf8da8c34f3d9fe218f038814fd1d310ac76c90", size = 679734, upload-time = "2025-11-17T22:31:39.223Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/cf/912146dfd4b5c0eea956836c01dcd2fce6c9c844b2691f5152aca196ce4f/ml_dtypes-0.5.4-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bc11d7e8c44a65115d05e2ab9989d1e045125d7be8e05a071a48bc76eb6d6040", size = 5056165, upload-time = "2025-11-17T22:31:41.071Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/80/19189ea605017473660e43762dc853d2797984b3c7bf30ce656099add30c/ml_dtypes-0.5.4-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:19b9a53598f21e453ea2fbda8aa783c20faff8e1eeb0d7ab899309a0053f1483", size = 5034975, upload-time = "2025-11-17T22:31:42.758Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/24/70bd59276883fdd91600ca20040b41efd4902a923283c4d6edcb1de128d2/ml_dtypes-0.5.4-cp311-cp311-win_amd64.whl", hash = "sha256:7c23c54a00ae43edf48d44066a7ec31e05fdc2eee0be2b8b50dd1903a1db94bb", size = 210742, upload-time = "2025-11-17T22:31:44.068Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/c9/64230ef14e40aa3f1cb254ef623bf812735e6bec7772848d19131111ac0d/ml_dtypes-0.5.4-cp311-cp311-win_arm64.whl", hash = "sha256:557a31a390b7e9439056644cb80ed0735a6e3e3bb09d67fd5687e4b04238d1de", size = 160709, upload-time = "2025-11-17T22:31:46.557Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b8/3c70881695e056f8a32f8b941126cf78775d9a4d7feba8abcb52cb7b04f2/ml_dtypes-0.5.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a174837a64f5b16cab6f368171a1a03a27936b31699d167684073ff1c4237dac", size = 676927, upload-time = "2025-11-17T22:31:48.182Z" },
+    { url = "https://files.pythonhosted.org/packages/54/0f/428ef6881782e5ebb7eca459689448c0394fa0a80bea3aa9262cba5445ea/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a7f7c643e8b1320fd958bf098aa7ecf70623a42ec5154e3be3be673f4c34d900", size = 5028464, upload-time = "2025-11-17T22:31:50.135Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/cb/28ce52eb94390dda42599c98ea0204d74799e4d8047a0eb559b6fd648056/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9ad459e99793fa6e13bd5b7e6792c8f9190b4e5a1b45c63aba14a4d0a7f1d5ff", size = 5009002, upload-time = "2025-11-17T22:31:52.001Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/f0/0cfadd537c5470378b1b32bd859cf2824972174b51b873c9d95cfd7475a5/ml_dtypes-0.5.4-cp312-cp312-win_amd64.whl", hash = "sha256:c1a953995cccb9e25a4ae19e34316671e4e2edaebe4cf538229b1fc7109087b7", size = 212222, upload-time = "2025-11-17T22:31:53.742Z" },
+    { url = "https://files.pythonhosted.org/packages/16/2e/9acc86985bfad8f2c2d30291b27cd2bb4c74cea08695bd540906ed744249/ml_dtypes-0.5.4-cp312-cp312-win_arm64.whl", hash = "sha256:9bad06436568442575beb2d03389aa7456c690a5b05892c471215bfd8cf39460", size = 160793, upload-time = "2025-11-17T22:31:55.358Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/a1/4008f14bbc616cfb1ac5b39ea485f9c63031c4634ab3f4cf72e7541f816a/ml_dtypes-0.5.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8c760d85a2f82e2bed75867079188c9d18dae2ee77c25a54d60e9cc79be1bc48", size = 676888, upload-time = "2025-11-17T22:31:56.907Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b7/dff378afc2b0d5a7d6cd9d3209b60474d9819d1189d347521e1688a60a53/ml_dtypes-0.5.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce756d3a10d0c4067172804c9cc276ba9cc0ff47af9078ad439b075d1abdc29b", size = 5036993, upload-time = "2025-11-17T22:31:58.497Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/33/40cd74219417e78b97c47802037cf2d87b91973e18bb968a7da48a96ea44/ml_dtypes-0.5.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:533ce891ba774eabf607172254f2e7260ba5f57bdd64030c9a4fcfbd99815d0d", size = 5010956, upload-time = "2025-11-17T22:31:59.931Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/8b/200088c6859d8221454825959df35b5244fa9bdf263fd0249ac5fb75e281/ml_dtypes-0.5.4-cp313-cp313-win_amd64.whl", hash = "sha256:f21c9219ef48ca5ee78402d5cc831bd58ea27ce89beda894428bc67a52da5328", size = 212224, upload-time = "2025-11-17T22:32:01.349Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/75/dfc3775cb36367816e678f69a7843f6f03bd4e2bcd79941e01ea960a068e/ml_dtypes-0.5.4-cp313-cp313-win_arm64.whl", hash = "sha256:35f29491a3e478407f7047b8a4834e4640a77d2737e0b294d049746507af5175", size = 160798, upload-time = "2025-11-17T22:32:02.864Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/74/e9ddb35fd1dd43b1106c20ced3f53c2e8e7fc7598c15638e9f80677f81d4/ml_dtypes-0.5.4-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:304ad47faa395415b9ccbcc06a0350800bc50eda70f0e45326796e27c62f18b6", size = 702083, upload-time = "2025-11-17T22:32:04.08Z" },
+    { url = "https://files.pythonhosted.org/packages/74/f5/667060b0aed1aa63166b22897fdf16dca9eb704e6b4bbf86848d5a181aa7/ml_dtypes-0.5.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6a0df4223b514d799b8a1629c65ddc351b3efa833ccf7f8ea0cf654a61d1e35d", size = 5354111, upload-time = "2025-11-17T22:32:05.546Z" },
+    { url = "https://files.pythonhosted.org/packages/40/49/0f8c498a28c0efa5f5c95a9e374c83ec1385ca41d0e85e7cf40e5d519a21/ml_dtypes-0.5.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:531eff30e4d368cb6255bc2328d070e35836aa4f282a0fb5f3a0cd7260257298", size = 5366453, upload-time = "2025-11-17T22:32:07.115Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/27/12607423d0a9c6bbbcc780ad19f1f6baa2b68b18ce4bddcdc122c4c68dc9/ml_dtypes-0.5.4-cp313-cp313t-win_amd64.whl", hash = "sha256:cb73dccfc991691c444acc8c0012bee8f2470da826a92e3a20bb333b1a7894e6", size = 225612, upload-time = "2025-11-17T22:32:08.615Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/80/5a5929e92c72936d5b19872c5fb8fc09327c1da67b3b68c6a13139e77e20/ml_dtypes-0.5.4-cp313-cp313t-win_arm64.whl", hash = "sha256:3bbbe120b915090d9dd1375e4684dd17a20a2491ef25d640a908281da85e73f1", size = 164145, upload-time = "2025-11-17T22:32:09.782Z" },
+    { url = "https://files.pythonhosted.org/packages/72/4e/1339dc6e2557a344f5ba5590872e80346f76f6cb2ac3dd16e4666e88818c/ml_dtypes-0.5.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:2b857d3af6ac0d39db1de7c706e69c7f9791627209c3d6dedbfca8c7e5faec22", size = 673781, upload-time = "2025-11-17T22:32:11.364Z" },
+    { url = "https://files.pythonhosted.org/packages/04/f9/067b84365c7e83bda15bba2b06c6ca250ce27b20630b1128c435fb7a09aa/ml_dtypes-0.5.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:805cef3a38f4eafae3a5bf9ebdcdb741d0bcfd9e1bd90eb54abd24f928cd2465", size = 5036145, upload-time = "2025-11-17T22:32:12.783Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/bb/82c7dcf38070b46172a517e2334e665c5bf374a262f99a283ea454bece7c/ml_dtypes-0.5.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14a4fd3228af936461db66faccef6e4f41c1d82fcc30e9f8d58a08916b1d811f", size = 5010230, upload-time = "2025-11-17T22:32:14.38Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/93/2bfed22d2498c468f6bcd0d9f56b033eaa19f33320389314c19ef6766413/ml_dtypes-0.5.4-cp314-cp314-win_amd64.whl", hash = "sha256:8c6a2dcebd6f3903e05d51960a8058d6e131fe69f952a5397e5dbabc841b6d56", size = 221032, upload-time = "2025-11-17T22:32:15.763Z" },
+    { url = "https://files.pythonhosted.org/packages/76/a3/9c912fe6ea747bb10fe2f8f54d027eb265db05dfb0c6335e3e063e74e6e8/ml_dtypes-0.5.4-cp314-cp314-win_arm64.whl", hash = "sha256:5a0f68ca8fd8d16583dfa7793973feb86f2fbb56ce3966daf9c9f748f52a2049", size = 163353, upload-time = "2025-11-17T22:32:16.932Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/02/48aa7d84cc30ab4ee37624a2fd98c56c02326785750cd212bc0826c2f15b/ml_dtypes-0.5.4-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:bfc534409c5d4b0bf945af29e5d0ab075eae9eecbb549ff8a29280db822f34f9", size = 702085, upload-time = "2025-11-17T22:32:18.175Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/e7/85cb99fe80a7a5513253ec7faa88a65306be071163485e9a626fce1b6e84/ml_dtypes-0.5.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2314892cdc3fcf05e373d76d72aaa15fda9fb98625effa73c1d646f331fcecb7", size = 5355358, upload-time = "2025-11-17T22:32:19.7Z" },
+    { url = "https://files.pythonhosted.org/packages/79/2b/a826ba18d2179a56e144aef69e57fb2ab7c464ef0b2111940ee8a3a223a2/ml_dtypes-0.5.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0d2ffd05a2575b1519dc928c0b93c06339eb67173ff53acb00724502cda231cf", size = 5366332, upload-time = "2025-11-17T22:32:21.193Z" },
+    { url = "https://files.pythonhosted.org/packages/84/44/f4d18446eacb20ea11e82f133ea8f86e2bf2891785b67d9da8d0ab0ef525/ml_dtypes-0.5.4-cp314-cp314t-win_amd64.whl", hash = "sha256:4381fe2f2452a2d7589689693d3162e876b3ddb0a832cde7a414f8e1adf7eab1", size = 236612, upload-time = "2025-11-17T22:32:22.579Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/3f/3d42e9a78fe5edf792a83c074b13b9b770092a4fbf3462872f4303135f09/ml_dtypes-0.5.4-cp314-cp314t-win_arm64.whl", hash = "sha256:11942cbf2cf92157db91e5022633c0d9474d4dfd813a909383bd23ce828a4b7d", size = 168825, upload-time = "2025-11-17T22:32:23.766Z" },
 ]
 
 [[package]]
@@ -2253,6 +2396,15 @@ wheels = [
 ]
 
 [[package]]
+name = "opt-einsum"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/b9/2ac072041e899a52f20cf9510850ff58295003aa75525e58343591b0cbfb/opt_einsum-3.4.0.tar.gz", hash = "sha256:96ca72f1b886d148241348783498194c577fa30a8faac108586b14f1ba4473ac", size = 63004, upload-time = "2024-09-26T14:33:24.483Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/cd/066e86230ae37ed0be70aae89aabf03ca8d9f39c8aea0dec8029455b5540/opt_einsum-3.4.0-py3-none-any.whl", hash = "sha256:69bb92469f86a1565195ece4ac0323943e83477171b91d24c35afe028a90d7cd", size = 71932, upload-time = "2024-09-26T14:33:23.039Z" },
+]
+
+[[package]]
 name = "oqae"
 version = "0.1.0"
 source = { editable = "." }
@@ -2276,6 +2428,11 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+benchmark = [
+    { name = "matplotlib" },
+    { name = "scib-metrics" },
+    { name = "umap-learn" },
+]
 dev = [
     { name = "autopep8" },
     { name = "black" },
@@ -2304,6 +2461,7 @@ requires-dist = [
     { name = "furo", marker = "extra == 'docs'", specifier = ">=2024.1.29" },
     { name = "huggingface-hub", specifier = ">=0.20.0" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.12.0" },
+    { name = "matplotlib", marker = "extra == 'benchmark'", specifier = ">=3.7.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.5.0" },
     { name = "numpy", specifier = ">=1.21.0" },
     { name = "omegaconf", specifier = ">=2.3.0" },
@@ -2312,6 +2470,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
     { name = "rich", specifier = ">=13.0.0" },
+    { name = "scib-metrics", marker = "extra == 'benchmark'", specifier = ">=0.5.0" },
     { name = "scipy", specifier = ">=1.9.0" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=7.0.0" },
     { name = "tiledbsoma", specifier = ">=1.12.0" },
@@ -2319,10 +2478,11 @@ requires-dist = [
     { name = "torch", specifier = ">=2.12.1" },
     { name = "transformers", specifier = ">=4.20.0" },
     { name = "typer", specifier = ">=0.9.0" },
+    { name = "umap-learn", marker = "extra == 'benchmark'", specifier = ">=0.5.4" },
     { name = "wandb", specifier = ">=0.21.0" },
     { name = "zarr", specifier = ">=3.0.0" },
 ]
-provides-extras = ["dev", "docs"]
+provides-extras = ["dev", "docs", "benchmark"]
 
 [[package]]
 name = "packaging"
@@ -2502,6 +2662,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
+]
+
+[[package]]
+name = "plottable"
+version = "0.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "matplotlib" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "pillow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/3e/15137d0dde8eb6721d2a42b8d45359f37c2fc76dd688903d04c6bdbf43c7/plottable-0.1.5.tar.gz", hash = "sha256:235d762a31c82129dc5bf74205c103a14b1e4393d0f921cc0231be5de884041d", size = 21616, upload-time = "2022-11-13T09:31:08.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/cf/23ea4b6f9460312604ed67b74e7db3e702fcaefc04743224ef1cdda663f4/plottable-0.1.5-py3-none-any.whl", hash = "sha256:5c5d1128d90065fc940e5c8445b2603d253909745bb0cee0c9828651b812441c", size = 24734, upload-time = "2022-11-13T09:31:01.102Z" },
 ]
 
 [[package]]
@@ -3256,7 +3431,8 @@ version = "1.12.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version >= '3.12' and python_full_version < '3.15'",
+    "python_full_version >= '3.13' and python_full_version < '3.15'",
+    "python_full_version == '3.12.*'",
 ]
 dependencies = [
     { name = "anndata", marker = "python_full_version >= '3.12'" },
@@ -3286,6 +3462,34 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/11/18/1ed26bd2231d9bbe9bfe6ba678fdd261d1ec664ab1bca1d30401dc2a9193/scanpy-1.12.1.tar.gz", hash = "sha256:489c6a3763311721089bf0d78e65fd1555606b45f1a9ee97aa85291a12ade67a", size = 14418570, upload-time = "2026-04-10T12:14:00.161Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/e4/b648ac3267001e1582e0b6ffc22b16dada83e206d783115992e83a07773f/scanpy-1.12.1-py3-none-any.whl", hash = "sha256:d482c92d0d7ae7b954a603e16dfcf5f062c511bd5e30e5dfd701c28e1d6b0e78", size = 2148436, upload-time = "2026-04-10T12:13:58.061Z" },
+]
+
+[[package]]
+name = "scib-metrics"
+version = "0.5.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anndata" },
+    { name = "chex" },
+    { name = "igraph" },
+    { name = "jax" },
+    { name = "jaxlib" },
+    { name = "matplotlib" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "plottable" },
+    { name = "pynndescent" },
+    { name = "rich" },
+    { name = "scanpy", version = "1.11.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "scanpy", version = "1.12.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+    { name = "tqdm" },
+    { name = "umap-learn" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/9f/88035070c491f611e7fdf554f7d917b048e5a2ec081c03fef5906ff8bea3/scib_metrics-0.5.9.tar.gz", hash = "sha256:60458403fac9b09b1f678d19b1663df118867d9d8a28bf31f657b604811f2591", size = 435869, upload-time = "2026-02-26T08:12:08.3Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/58/acb9d7402d5a58867e2f17ef81cb4b95fc7602aba53235a6918882f5e718/scib_metrics-0.5.9-py3-none-any.whl", hash = "sha256:46f9cc64295efa3ea9e505e29804a2ae319601eb4b6248eefd66217a1dccca49", size = 39244, upload-time = "2026-02-26T08:12:06.791Z" },
 ]
 
 [[package]]
@@ -3426,7 +3630,8 @@ version = "0.0.8"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version >= '3.12' and python_full_version < '3.15'",
+    "python_full_version >= '3.13' and python_full_version < '3.15'",
+    "python_full_version == '3.12.*'",
 ]
 dependencies = [
     { name = "session-info2", marker = "python_full_version >= '3.12'" },
@@ -3643,7 +3848,8 @@ version = "9.1.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version >= '3.12' and python_full_version < '3.15'",
+    "python_full_version >= '3.13' and python_full_version < '3.15'",
+    "python_full_version == '3.12.*'",
 ]
 dependencies = [
     { name = "alabaster", marker = "python_full_version >= '3.12'" },
@@ -3788,6 +3994,15 @@ wheels = [
 ]
 
 [[package]]
+name = "texttable"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/dc/0aff23d6036a4d3bf4f1d8c8204c5c79c4437e25e0ae94ffe4bbb55ee3c2/texttable-1.7.0.tar.gz", hash = "sha256:2d2068fb55115807d3ac77a4ca68fa48803e84ebb0ee2340f858107a36522638", size = 12831, upload-time = "2023-10-03T09:48:12.272Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/99/4772b8e00a136f3e01236de33b0efda31ee7077203ba5967fcc76da94d65/texttable-1.7.0-py2.py3-none-any.whl", hash = "sha256:72227d592c82b3d7f672731ae73e4d1f88cd8e2ef5b075a7a7f01a23a3743917", size = 10768, upload-time = "2023-10-03T09:48:10.434Z" },
+]
+
+[[package]]
 name = "threadpoolctl"
 version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3926,6 +4141,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
     { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "toolz"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/d6/114b492226588d6ff54579d95847662fc69196bdeec318eb45393b24c192/toolz-1.1.0.tar.gz", hash = "sha256:27a5c770d068c110d9ed9323f24f1543e83b2f300a687b7891c1a6d56b697b5b", size = 52613, upload-time = "2025-10-17T04:03:21.661Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl", hash = "sha256:15ccc861ac51c53696de0a5d6d4607f99c210739caf987b5d2054f3efed429d8", size = 58093, upload-time = "2025-10-17T04:03:20.435Z" },
 ]
 
 [[package]]
@@ -4336,7 +4560,8 @@ version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version >= '3.12' and python_full_version < '3.15'",
+    "python_full_version >= '3.13' and python_full_version < '3.15'",
+    "python_full_version == '3.12.*'",
 ]
 dependencies = [
     { name = "donfig", marker = "python_full_version >= '3.12'" },


### PR DESCRIPTION
Closes #36.

Adds three offline latent-quality upgrades so we can judge a model beyond the nearest-centroid separability proxy. No change to the core dependency footprint — the heavy libs live in a new optional `benchmark` extra and are lazy-imported.

## What's in it

### A. Quantization-cost view (no new deps)
- `inference.encode` / `EncodedCells` now also return `quantized` — the post-quantization latent (the discrete codes embedded back into latent space). Free: it reuses the same `model.quantize(z)` call already in the encode loop.
- `evaluate_model` reports `separability` (continuous `z`), `separability_quantized`, and their `separability_gap` — how much label structure the RVQ bottleneck discards. Small gap ⇒ quantization is cheap; large gap ⇒ the codebook is the bottleneck. Surfaced as `sep_quant` / `sep_gap` columns and in `results_to_dicts`.

### B. scIB clustering metrics (optional `benchmark` extra)
- `benchmark/clustering.py::clustering_metrics` → NMI / ARI (KMeans) + cell-type ASW via `scib-metrics`.
- **Opt-in** via `compute_clustering=True` on `evaluate_model` / `run_benchmark` / `run_suite`; lazy-imported so the default path never pulls jax/scib. The `nmi` / `ari` / `ct_asw` table columns appear only when computed.

### C. UMAP visualization (optional `benchmark` extra)
- `benchmark/viz.py::plot_latent_umap` (+ `compute_umap`): a grid of UMAP scatters, rows = `latent` / `quantized`, columns = `labels` / `color_by` (batch view). Raw integer codes are intentionally **not** UMAP'd (Euclidean distance on codebook indices is meaningless).

## Deps / packaging
- New `benchmark` extra: `scib-metrics`, `umap-learn`, `matplotlib`; `uv.lock` refreshed. Not in `dev`; `import omvqvae` stays light.

## Tests
- Part A: unconditional (encode `quantized` shape/equivalence, harness gap maths, table/dict columns).
- Parts B/C: guarded with `pytest.importorskip` — they run in CI (all extras installed) and skip cleanly on a core install.
- `examples/07_latent_quality.py` demonstrates the flow on synthetic data (+ smoke tests, one with the extra and one core-only).
- `make ci` green: 251 passed, ~99.6% coverage, mypy strict / flake8 / black clean.

## Follow-up
- #37 — scVI baseline behind a `LatentModel` protocol, reusing these shared latent metrics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)