### PR TITLE
scVI baseline behind a LatentModel protocol (#37)

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -296,8 +296,34 @@
     `compute_clustering=True` + a saved UMAP. Tests: clustering/viz guarded with
     `importorskip` (run in CI since all extras are installed); Part A tests are
     unconditional. `make ci` green (249 passed, ~99.6%).
-  - **Follow-up (issue #37):** scVI baseline behind a `LatentModel` protocol,
-    reusing these shared latent metrics.
+- **scVI baseline behind a `LatentModel` protocol (issue #37) — DONE (this PR,
+  branch `claude/scvi-baseline`).** Lets us anchor OQAE's dataset/metric-relative
+  separability against a well-tested external VAE on the **same cells, genes, and
+  metrics**.
+  - `benchmark/baselines.py` — a thin `LatentModel` `Protocol`
+    (`name` + `fit(train_counts, *, genes, labels=None)` + `embed(counts) ->
+    (n_cells, d)`) and two adapters: `OmvqvaeLatentModel` (config-driven training
+    of an `OmicsVQVAE`, or wrap an already-trained model; `embed` returns the
+    continuous latent, or the post-quantization `.quantized` view opt-in) and
+    `ScviLatentModel` (wraps `scvi.model.SCVI`, **lazy-imported** with a clear
+    "install the `baselines` extra" error; trains unconditionally to match v1
+    OQAE). `compare_latent_models(models, eval_counts, labels, batch_key=None)`
+    embeds shared held-out cells through each fitted model and scores them with
+    the **same** shared metrics (`separability_score` + optional scIB
+    `clustering_metrics`), emitting a one-row-per-model table
+    (`format_latent_comparison` / `latent_comparison_to_dicts`). Reconstruction
+    NLL is deliberately **not** compared (incomparable units across likelihoods).
+  - New optional `baselines` extra (`scvi-tools>=1.1.0`), kept out of `dev` and
+    the offline default suite; `uv.lock` refreshed. Added the `scvi.*` mypy
+    ignore-missing override. `examples/compare_scvi.py` mirrors the config-sweep
+    examples (train OQAE + scVI on the same data, print the comparison, save a
+    UMAP per model); runs the OQAE-only path offline, full scVI path under the
+    `network` marker.
+  - Offline tests cover the OQAE adapter (fit/embed, wrap-a-trained-model,
+    quantized view, every guard), the scVI missing-dependency error (via
+    `sys.modules` hiding), and `compare_latent_models` + reporting; the scVI
+    training/embedding shell is `# pragma: no cover` + `@pytest.mark.network`.
+    `make ci` green (274 passed, ~99.6%); `make docs` clean.
 
 ## Next task — PR #10: v1.0 release
 
@@ -351,6 +377,18 @@ freeze audit** (offline, no new deps), with packaging/PyPI as a follow-up.
 
 ## Changelog (most recent first)
 
+- **2026-07-01** — Issue #37: scVI baseline behind a `LatentModel` protocol
+  (branch `claude/scvi-baseline`). Added `src/omvqvae/benchmark/baselines.py` —
+  the `LatentModel` `Protocol`, `OmvqvaeLatentModel` / `ScviLatentModel` adapters
+  (scVI lazy-imported behind a new optional `baselines` extra), and
+  `compare_latent_models` + `format_latent_comparison` /
+  `latent_comparison_to_dicts` scoring both models with the shared latent metrics
+  on the same cells/genes (no cross-model reconstruction NLL). Added
+  `examples/compare_scvi.py` (OQAE-vs-scVI, OQAE-only path offline, full path
+  network-gated), the `baselines` extra + `scvi.*` mypy override (`uv.lock`
+  refreshed), and Sphinx `api.rst` + `examples/README.md` entries. Offline tests
+  at ~100% on the new module (scVI shell `# pragma: no cover` + `network`);
+  `make ci` green (274 passed, ~99.6%), `make docs` clean.
 - **2026-06-30** — PR #9 slice 3: Census streaming throughput/scaling. Added
   `src/omvqvae/benchmark/throughput.py` — `measure_stream_throughput` (the pure,
   offline-tested timing core over any `Minibatch` stream: cells/s, batches/s,

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -83,6 +83,9 @@ a comparison-table report.
 .. automodule:: omvqvae.benchmark.throughput
    :members:
 
+.. automodule:: omvqvae.benchmark.baselines
+   :members:
+
 Serialization (:mod:`omvqvae.hf_utils`)
 ---------------------------------------
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,6 +14,7 @@ CELLxGENE Census and need network access.
 | 5 | [`05_benchmark_report.py`](05_benchmark_report.py) | Run the full PR #9 sweep (NB vs ZINB vs Gaussian, codebook sweeps) on a larger fixture and write the interpreted [`docs/benchmark_report.md`](../docs/benchmark_report.md). | ✅ |
 | 6 | [`06_census_throughput.py`](06_census_throughput.py) | Profile Census streaming throughput (cells/s, time-to-first-batch) — raw streaming vs end-to-end with a model train step. | ❌ (network) |
 | 7 | [`07_latent_quality.py`](07_latent_quality.py) | Latent-quality metrics: quantization gap (continuous vs post-quantization separability), scIB clustering (NMI / ARI / cell-type ASW), and a latent UMAP. Needs the `benchmark` extra. | ✅ |
+| — | [`compare_scvi.py`](compare_scvi.py) | Compare OQAE against an **scVI** baseline behind the model-agnostic `LatentModel` protocol: same cells / genes / metrics, side-by-side separability + scIB clustering + UMAPs. Needs the `baselines` (scVI) and `benchmark` extras. | ✅ (OQAE-only) |
 
 ## Running
 
@@ -27,6 +28,7 @@ uv run python examples/04_benchmark_configs.py
 uv run python examples/05_benchmark_report.py   # writes docs/benchmark_report.md
 uv run python examples/06_census_throughput.py  # requires network (Census)
 uv run python examples/07_latent_quality.py      # needs the `benchmark` extra
+uv run python examples/compare_scvi.py           # OQAE vs scVI; needs the `baselines` extra
 ```
 
 Each script exposes a `main()` function, so it can also be imported and driven
@@ -66,4 +68,6 @@ raw counts ──encode──► codes (n_cells, n_codebooks) ──decode──
   and `make_benchmark_fixture` / `default_report_configs` / `generate_report`
   (the full sweep + interpreted Markdown report), plus
   `measure_stream_throughput` / `benchmark_census_throughput` (streaming
-  throughput / scaling).
+  throughput / scaling) and `OmvqvaeLatentModel` / `ScviLatentModel` /
+  `compare_latent_models` (compare OQAE against external latent baselines such as
+  scVI behind the `LatentModel` protocol).

--- a/examples/compare_scvi.py
+++ b/examples/compare_scvi.py
@@ -1,0 +1,160 @@
+"""
+Compare OQAE against an scVI baseline on the same cells, genes, and metrics.
+
+OQAE's own benchmark ranks OQAE configurations but cannot tell you whether an
+absolute separability of ``~0.7`` is good — that number is entirely
+dataset/metric dependent. Running scVI (a well-tested external VAE) on the
+**same cells, same genes, same metric** turns "0.70 in a vacuum" into a claim:
+matched vs. a real gap.
+
+This example wires both models behind the model-agnostic
+:class:`~omvqvae.benchmark.baselines.LatentModel` protocol and scores them with
+the shared latent metrics:
+
+- :class:`~omvqvae.benchmark.baselines.OmvqvaeLatentModel` trains an
+  ``OmicsVQVAE`` and embeds the continuous latent;
+- :class:`~omvqvae.benchmark.baselines.ScviLatentModel` trains
+  ``scvi.model.SCVI`` and embeds ``get_latent_representation()``;
+- :func:`~omvqvae.benchmark.baselines.compare_latent_models` embeds the shared
+  held-out cells through both and tabulates separability + scIB NMI/ARI/ASW.
+
+Fairness (see ``benchmark/baselines.py``): both models see the same gene panel,
+the same cells, and the same train/eval split; scVI trains **unconditionally**
+(no ``batch_key``) to match v1 OQAE; and no reconstruction NLL is compared
+across models (incomparable units).
+
+This script runs on tiny **synthetic** data so it is self-contained and fast.
+For the real comparison, swap :func:`make_synthetic_anndata` for a local
+``.h5ad`` of raw counts (e.g. Tabula Sapiens bone marrow) aligned to a curated
+gene panel — see the commented block in :func:`main`.
+
+The scVI pieces need the optional ``baselines`` extra
+(``uv sync --extra baselines``); the clustering / UMAP pieces need the
+``benchmark`` extra. Run::
+
+    python examples/compare_scvi.py
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List, Optional, Tuple
+
+import numpy as np
+
+from omvqvae.benchmark import (
+    BenchmarkConfig,
+    OmvqvaeLatentModel,
+    ScviLatentModel,
+    compare_latent_models,
+    format_latent_comparison,
+    plot_latent_umap,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from matplotlib.figure import Figure
+
+
+def _synthetic_split() -> Tuple[np.ndarray, np.ndarray, List[str], List[str], List[str]]:
+    """A tiny raw-count train/eval split with program labels and gene ids."""
+    from synthetic_data import make_synthetic_anndata  # sibling example helper
+
+    adata = make_synthetic_anndata(n_cells=400, n_genes=32, n_programs=5)
+    counts = np.asarray(adata.X, dtype=np.float32)
+    genes = list(adata.var_names)
+    labels = list(adata.obs["program"])
+
+    rng = np.random.default_rng(0)
+    perm = rng.permutation(counts.shape[0])
+    n_train = int(round(0.8 * counts.shape[0]))
+    train_idx, eval_idx = perm[:n_train], perm[n_train:]
+    train_counts = counts[train_idx]
+    eval_counts = counts[eval_idx]
+    eval_labels = [labels[i] for i in eval_idx]
+    return train_counts, eval_counts, genes, eval_labels, labels
+
+
+def main(
+    *,
+    use_scvi: bool = True,
+    compute_clustering: bool = True,
+    make_umap: bool = True,
+) -> Tuple[str, Optional["Figure"], Optional["Figure"]]:
+    """
+    Train OQAE (+ scVI), tabulate the shared latent metrics, and plot UMAPs.
+
+    Parameters
+    ----------
+    use_scvi : bool, default True
+        Include the scVI baseline (needs the ``baselines`` extra). Set False to
+        run the OQAE-only path on a core install.
+    compute_clustering : bool, default True
+        Also compute NMI / ARI / cell-type ASW (needs the ``benchmark`` extra).
+    make_umap : bool, default True
+        Render and return per-model latent UMAP figures.
+
+    Returns
+    -------
+    (str, Figure or None, Figure or None)
+        The comparison table and the OQAE / scVI UMAP figures (``None`` when a
+        model is absent or ``make_umap`` is False).
+    """
+    train_counts, eval_counts, genes, eval_labels, _ = _synthetic_split()
+
+    # --- Swap in real data for a meaningful comparison: -------------------- #
+    # from omvqvae.data import (GeneVocabulary, load_anndata, extract_counts)
+    # from omvqvae.data.anndata_io import align_to_reference
+    # adata = load_anndata("/path/to/tab-sap-marrow.h5ad")
+    # counts, gene_ids = extract_counts(adata)
+    # panel = [l.strip() for l in open("resources/gene_selection_2k.txt")]
+    # vocab = GeneVocabulary("homo_sapiens", panel)
+    # aligned = align_to_reference(counts, gene_ids, vocab, min_overlap=500)
+    # (then split `aligned` / `adata.obs["cell_type"]` into train/eval)
+    # ----------------------------------------------------------------------- #
+
+    # OQAE behind the protocol: a realistic-ish config trained on the raw counts.
+    oqae_config = BenchmarkConfig(
+        name="OQAE",
+        likelihood="nb",
+        n_codebooks=2,
+        codebook_size=64,
+        n_latent=16,
+        hidden_dims=(64,),
+        max_epochs=8,
+    )
+    oqae = OmvqvaeLatentModel(oqae_config, batch_size=128)
+    oqae.fit(train_counts, genes=genes)
+
+    models: List = [oqae]
+    if use_scvi:
+        # Leave max_epochs=None in real runs for scVI's own budget / early
+        # stopping; a small cap keeps this synthetic demo fast.
+        scvi_model = ScviLatentModel(name="scVI", n_latent=10, max_epochs=20)
+        scvi_model.fit(train_counts, genes=genes)
+        models.append(scvi_model)
+
+    reports = compare_latent_models(
+        models, eval_counts, eval_labels, compute_clustering=compute_clustering
+    )
+    table = format_latent_comparison(reports)
+    print(table)
+
+    if not make_umap:
+        return table, None, None
+
+    oqae_fig = plot_latent_umap(oqae.embed(eval_counts), eval_labels, n_neighbors=15)
+    scvi_fig = None
+    if use_scvi:
+        scvi_fig = plot_latent_umap(
+            models[1].embed(eval_counts), eval_labels, n_neighbors=15
+        )
+    return table, oqae_fig, scvi_fig
+
+
+if __name__ == "__main__":
+    _, oqae_figure, scvi_figure = main()
+    if oqae_figure is not None:
+        oqae_figure.savefig("oqae_umap.png", dpi=150, bbox_inches="tight")
+        print("wrote oqae_umap.png")
+    if scvi_figure is not None:
+        scvi_figure.savefig("scvi_umap.png", dpi=150, bbox_inches="tight")
+        print("wrote scvi_umap.png")

--- a/examples/compare_scvi.py
+++ b/examples/compare_scvi.py
@@ -74,8 +74,46 @@ def _synthetic_split() -> Tuple[np.ndarray, np.ndarray, List[str], List[str], Li
     return train_counts, eval_counts, genes, eval_labels, labels
 
 
+#: Real-data default: a local Tabula Sapiens bone-marrow ``.h5ad`` aligned to the
+#: committed 2k gene panel. Falls back to synthetic data when the file is absent
+#: (e.g. in CI), so the example stays runnable everywhere.
+DEFAULT_DATA_PATH = Path("/Volumes/sandisk_2tb/dev/oqae/data/tab-sap-marrow.h5ad")
+
+
+def _real_split(
+    data_path: Path,
+) -> Tuple[np.ndarray, np.ndarray, List[str], List[str], List[str]]:
+    """Load a local ``.h5ad``, align to the 2k panel, and split train/eval."""
+    from omvqvae.data import GeneVocabulary, extract_counts, load_anndata
+    from omvqvae.data.anndata_io import align_to_reference
+
+    panel_path = (
+        Path(__file__).resolve().parents[1] / "resources" / "gene_selection_2k.txt"
+    )
+    adata = load_anndata(data_path)
+    counts, gene_ids = extract_counts(adata)
+    panel = [ln.strip() for ln in panel_path.read_text().splitlines() if ln.strip()]
+    vocab = GeneVocabulary("homo_sapiens", panel)
+    aligned = align_to_reference(counts, gene_ids, vocab, min_overlap=500)
+    labels = list(adata.obs["cell_type"])
+
+    rng = np.random.default_rng(0)
+    perm = rng.permutation(aligned.shape[0])
+    n_train = int(round(0.8 * aligned.shape[0]))
+    train_idx, eval_idx = perm[:n_train], perm[n_train:]
+    eval_labels = [labels[i] for i in eval_idx]
+    return (
+        aligned[train_idx],
+        aligned[eval_idx],
+        list(vocab.gene_ids),
+        eval_labels,
+        labels,
+    )
+
+
 def main(
     *,
+    data_path: Optional[Path] = None,
     use_scvi: bool = True,
     compute_clustering: bool = True,
     make_umap: bool = True,
@@ -85,6 +123,10 @@ def main(
 
     Parameters
     ----------
+    data_path : pathlib.Path, optional
+        Local ``.h5ad`` of raw counts to compare on (defaults to
+        :data:`DEFAULT_DATA_PATH`). When the file is missing, the example falls
+        back to the tiny synthetic split so it still runs anywhere.
     use_scvi : bool, default True
         Include the scVI baseline (needs the ``baselines`` extra). Set False to
         run the OQAE-only path on a core install.
@@ -99,29 +141,12 @@ def main(
         The comparison table and the OQAE / scVI UMAP figures (``None`` when a
         model is absent or ``make_umap`` is False).
     """
-    data_path = Path("/Volumes/sandisk_2tb/dev/oqae/data/tab-sap-marrow.h5ad")
-    panel_path = Path(__file__).resolve().parents[1] / "resources" / "gene_selection_2k.txt"
-
-    from omvqvae.data import GeneVocabulary, load_anndata, extract_counts
-    from omvqvae.data.anndata_io import align_to_reference
-
-    adata = load_anndata(data_path)
-    counts, gene_ids = extract_counts(adata)
-    panel = [line.strip() for line in panel_path.read_text().splitlines() if line.strip()]
-    vocab = GeneVocabulary("homo_sapiens", panel)
-    aligned = align_to_reference(counts, gene_ids, vocab, min_overlap=500)
-
-    labels = list(adata.obs["cell_type"])
-    rng = np.random.default_rng(0)
-    perm = rng.permutation(aligned.shape[0])
-    n_train = int(round(0.8 * aligned.shape[0]))
-    train_idx, eval_idx = perm[:n_train], perm[n_train:]
-    train_counts = aligned[train_idx]
-    eval_counts = aligned[eval_idx]
-    eval_labels = [labels[i] for i in eval_idx]
-    genes = vocab.gene_ids
-
-    # OQAE behind the protocol: a realistic-ish config trained on the raw counts.
+    path = DEFAULT_DATA_PATH if data_path is None else data_path
+    if path.exists():
+        train_counts, eval_counts, genes, eval_labels, _ = _real_split(path)
+    else:
+        print(f"{path} not found — falling back to synthetic data.")
+        train_counts, eval_counts, genes, eval_labels, _ = _synthetic_split()
 
     # OQAE behind the protocol: a realistic-ish config trained on the raw counts.
     oqae_config = BenchmarkConfig(

--- a/examples/compare_scvi.py
+++ b/examples/compare_scvi.py
@@ -37,6 +37,7 @@ The scVI pieces need the optional ``baselines`` extra
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
 import numpy as np
@@ -98,18 +99,29 @@ def main(
         The comparison table and the OQAE / scVI UMAP figures (``None`` when a
         model is absent or ``make_umap`` is False).
     """
-    train_counts, eval_counts, genes, eval_labels, _ = _synthetic_split()
+    data_path = Path("/Volumes/sandisk_2tb/dev/oqae/data/tab-sap-marrow.h5ad")
+    panel_path = Path(__file__).resolve().parents[1] / "resources" / "gene_selection_2k.txt"
 
-    # --- Swap in real data for a meaningful comparison: -------------------- #
-    # from omvqvae.data import (GeneVocabulary, load_anndata, extract_counts)
-    # from omvqvae.data.anndata_io import align_to_reference
-    # adata = load_anndata("/path/to/tab-sap-marrow.h5ad")
-    # counts, gene_ids = extract_counts(adata)
-    # panel = [l.strip() for l in open("resources/gene_selection_2k.txt")]
-    # vocab = GeneVocabulary("homo_sapiens", panel)
-    # aligned = align_to_reference(counts, gene_ids, vocab, min_overlap=500)
-    # (then split `aligned` / `adata.obs["cell_type"]` into train/eval)
-    # ----------------------------------------------------------------------- #
+    from omvqvae.data import GeneVocabulary, load_anndata, extract_counts
+    from omvqvae.data.anndata_io import align_to_reference
+
+    adata = load_anndata(data_path)
+    counts, gene_ids = extract_counts(adata)
+    panel = [line.strip() for line in panel_path.read_text().splitlines() if line.strip()]
+    vocab = GeneVocabulary("homo_sapiens", panel)
+    aligned = align_to_reference(counts, gene_ids, vocab, min_overlap=500)
+
+    labels = list(adata.obs["cell_type"])
+    rng = np.random.default_rng(0)
+    perm = rng.permutation(aligned.shape[0])
+    n_train = int(round(0.8 * aligned.shape[0]))
+    train_idx, eval_idx = perm[:n_train], perm[n_train:]
+    train_counts = aligned[train_idx]
+    eval_counts = aligned[eval_idx]
+    eval_labels = [labels[i] for i in eval_idx]
+    genes = vocab.gene_ids
+
+    # OQAE behind the protocol: a realistic-ish config trained on the raw counts.
 
     # OQAE behind the protocol: a realistic-ish config trained on the raw counts.
     oqae_config = BenchmarkConfig(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,11 @@ benchmark = [
     "umap-learn>=0.5.4",
     "matplotlib>=3.7.0",
 ]
+# External latent baselines (scVI) for the model-agnostic comparison. Heavy and
+# kept out of the default install / offline suite; see benchmark/baselines.py.
+baselines = [
+    "scvi-tools>=1.1.0",
+]
 
 [project.scripts]
 oqae-train = "omvqvae.train.cli:main"
@@ -128,6 +133,7 @@ module = [
     "tiledbsoma_ml.*",
     "scib_metrics.*",
     "umap.*",
+    "scvi.*",
 ]
 ignore_missing_imports = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,12 +138,14 @@ module = [
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
-# Sphinx (installed via the ``docs`` extra) is never imported by ``omvqvae`` but
-# is reachable in mypy's transitive import graph. Don't follow into its source:
-# recent Sphinx uses PEP 695 ``type`` statements that fail to parse under the
-# pinned 3.11 grammar (only surfaces on a 3.12 interpreter).
+# Sphinx (docs extra) and zarr (a transitive anndata dependency) are reachable in
+# mypy's import graph but never type-relevant to ``omvqvae``. Don't follow into
+# their source: recent releases use PEP 695 ``type`` statements / type-parameter
+# lists that fail to parse under the pinned 3.11 grammar (zarr>=3.2 only ships on
+# a 3.12+ interpreter, so this only surfaces there).
 module = [
     "sphinx.*",
+    "zarr.*",
 ]
 follow_imports = "skip"
 ignore_missing_imports = true

--- a/src/omvqvae/benchmark/__init__.py
+++ b/src/omvqvae/benchmark/__init__.py
@@ -15,6 +15,15 @@ stream later.
 
 from __future__ import annotations
 
+from omvqvae.benchmark.baselines import (
+    LatentModel,
+    LatentModelReport,
+    OmvqvaeLatentModel,
+    ScviLatentModel,
+    compare_latent_models,
+    format_latent_comparison,
+    latent_comparison_to_dicts,
+)
 from omvqvae.benchmark.clustering import ClusteringMetrics, clustering_metrics
 from omvqvae.benchmark.harness import (
     BenchmarkConfig,
@@ -50,6 +59,13 @@ from omvqvae.benchmark.throughput import (
 from omvqvae.benchmark.viz import compute_umap, plot_latent_umap
 
 __all__ = [
+    "LatentModel",
+    "LatentModelReport",
+    "OmvqvaeLatentModel",
+    "ScviLatentModel",
+    "compare_latent_models",
+    "latent_comparison_to_dicts",
+    "format_latent_comparison",
     "BenchmarkConfig",
     "BenchmarkResult",
     "EvalMetrics",

--- a/src/omvqvae/benchmark/baselines.py
+++ b/src/omvqvae/benchmark/baselines.py
@@ -1,0 +1,612 @@
+"""
+Model-agnostic latent baselines for the OQAE benchmarking harness.
+
+OQAE's benchmark tells us the *relatively* best OQAE configuration, but a bare
+separability of ``0.70`` is uninterpretable on its own — the number is entirely
+dataset/metric dependent. Running a well-tested external VAE on the **same
+cells, same genes, same metric** turns that into a claim: OQAE ``0.70`` vs scVI
+``0.72`` means "essentially matched, the dataset is just hard", while ``0.70``
+vs ``0.85`` means "a real gap to close".
+
+scVI does not fit :class:`~omvqvae.models.vqvae.OmicsVQVAE` /
+:class:`~omvqvae.benchmark.harness.BenchmarkConfig`, and we should not force it
+to. Every metric that transfers across models needs only a **latent embedding**,
+so this module defines a thin :class:`LatentModel` protocol and adapts both
+models to it:
+
+- :class:`OmvqvaeLatentModel` wraps a trained ``OmicsVQVAE``; ``embed`` returns
+  the continuous pre-quantization latent (or, opt-in, the post-quantization
+  ``.quantized`` variant for the quantization-gap view).
+- :class:`ScviLatentModel` wraps ``scvi.model.SCVI``; ``embed`` returns
+  ``get_latent_representation()``. ``scvi-tools`` is **lazy-imported** (project
+  idiom) and only pulled in via the optional ``baselines`` extra.
+
+:func:`compare_latent_models` then runs the **same** shared latent metrics
+(:func:`~omvqvae.benchmark.metrics.separability_score`,
+:func:`~omvqvae.benchmark.clustering.clustering_metrics`) over every model and
+emits a tidy one-row-per-model comparison table.
+
+Fairness constraints (read before comparing):
+
+- **Do not compare reconstruction NLL across models.** Different
+  likelihood/normalization conventions make the units incomparable; only
+  latent-based metrics (separability, NMI/ARI, UMAP) transfer. This module
+  deliberately reports no reconstruction metric.
+- **Match covariate treatment.** v1 OQAE is unconditional, so the scVI adapter
+  trains with **no ``batch_key``** by default. Feed both models the same gene
+  panel, the same cells, and the same train/eval split.
+- **Give scVI a realistic training budget.** Leave ``max_epochs=None`` so scVI
+  uses its own heuristic / early stopping, rather than the tiny epoch counts
+  used for OQAE smoke sweeps — otherwise the baseline is strawmanned.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Optional,
+    Protocol,
+    Sequence,
+    runtime_checkable,
+)
+
+import numpy as np
+
+from omvqvae.utils.logging import get_logger
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from omvqvae.benchmark.harness import BenchmarkConfig
+    from omvqvae.data.normalize import CountMatrix
+    from omvqvae.models.vqvae import OmicsVQVAE
+
+logger = get_logger(__name__)
+
+__all__ = [
+    "LatentModel",
+    "OmvqvaeLatentModel",
+    "ScviLatentModel",
+    "LatentModelReport",
+    "compare_latent_models",
+    "latent_comparison_to_dicts",
+    "format_latent_comparison",
+]
+
+_SCVI_MISSING_MSG = (
+    "ScviLatentModel requires the optional 'scvi-tools' dependency. Install the "
+    "baselines extra, e.g. `uv sync --extra baselines` or "
+    "`pip install 'oqae[baselines]'`."
+)
+
+
+@runtime_checkable
+class LatentModel(Protocol):
+    """
+    Minimal interface every latent baseline exposes for the comparison.
+
+    A ``LatentModel`` is any object that can be **fit** on a raw-count training
+    matrix and then **embed** raw counts into a continuous latent space. That is
+    all the shared latent metrics need, which is what lets OQAE and an external
+    VAE such as scVI be compared on equal footing.
+
+    Attributes
+    ----------
+    name : str
+        Human-readable label for the model's row in the comparison table.
+    """
+
+    name: str
+
+    def fit(
+        self,
+        train_counts: "CountMatrix",
+        *,
+        genes: Sequence[str],
+        labels: Optional[Sequence[object]] = None,
+    ) -> None:
+        """Train the model on raw counts ``(n_cells, n_genes)``."""
+        ...
+
+    def embed(self, counts: "CountMatrix") -> np.ndarray:
+        """Embed raw counts into a ``(n_cells, d)`` latent array."""
+        ...
+
+
+def _counts_to_array(counts: "CountMatrix") -> np.ndarray:
+    """Coerce a dense/sparse/tensor count matrix to a 2-D float32 NumPy array."""
+    from omvqvae.data.normalize import to_dense
+
+    dense = to_dense(counts)
+    array = np.asarray(dense, dtype=np.float32)
+    if array.ndim != 2:
+        raise ValueError(f"counts must be 2-D (n_cells, n_genes); got {array.ndim}-D.")
+    return array
+
+
+class OmvqvaeLatentModel:
+    """
+    OQAE adapter: train an :class:`~omvqvae.models.vqvae.OmicsVQVAE` and embed.
+
+    Two construction paths:
+
+    - Pass a :class:`~omvqvae.benchmark.harness.BenchmarkConfig` and call
+      :meth:`fit` — the adapter builds and trains a fresh model on the training
+      counts (the usual "train OQAE and scVI on the same data" comparison).
+    - Pass an already-``trained_model`` — :meth:`fit` becomes a no-op (beyond a
+      feature-size check), so a model trained elsewhere can be dropped straight
+      into the comparison.
+
+    Parameters
+    ----------
+    config : BenchmarkConfig, optional
+        Architecture / training knobs used to build and train the model in
+        :meth:`fit`. Mutually exclusive with ``trained_model``.
+    trained_model : OmicsVQVAE, optional
+        A pre-trained model to wrap directly. Mutually exclusive with ``config``.
+    name : str, optional
+        Row label; defaults to ``config.name`` (or ``"oqae"`` for a wrapped
+        model).
+    organism : str, default "homo_sapiens"
+        Organism id recorded on the training minibatches.
+    batch_size : int, default 128
+        Minibatch size for the training ``DataLoader`` built in :meth:`fit`.
+    use_quantized : bool, default False
+        When True, :meth:`embed` returns the **post-quantization** latent (the
+        codes embedded back into latent space) instead of the continuous
+        pre-quantization latent — the "what the discrete bottleneck keeps" view.
+
+    Raises
+    ------
+    ValueError
+        If neither or both of ``config`` / ``trained_model`` are given.
+    """
+
+    def __init__(
+        self,
+        config: Optional["BenchmarkConfig"] = None,
+        *,
+        trained_model: Optional["OmicsVQVAE"] = None,
+        name: Optional[str] = None,
+        organism: str = "homo_sapiens",
+        batch_size: int = 128,
+        use_quantized: bool = False,
+    ) -> None:
+        if (config is None) == (trained_model is None):
+            raise ValueError("Provide exactly one of `config` or `trained_model`.")
+        self.config = config
+        self.organism = organism
+        self.batch_size = batch_size
+        self.use_quantized = use_quantized
+        self._model: Optional["OmicsVQVAE"] = trained_model
+        if name is not None:
+            self.name = name
+        elif config is not None:
+            self.name = config.name
+        else:
+            self.name = "oqae"
+
+    def fit(
+        self,
+        train_counts: "CountMatrix",
+        *,
+        genes: Sequence[str],
+        labels: Optional[Sequence[object]] = None,
+    ) -> None:
+        """
+        Train an ``OmicsVQVAE`` on ``train_counts`` (no-op if wrapping a model).
+
+        ``labels`` are ignored (OQAE is unsupervised). ``genes`` only fixes the
+        feature-space size; a wrapped pre-trained model is validated against it.
+        """
+        counts = _counts_to_array(train_counts)
+        n_genes = counts.shape[1]
+        if len(genes) != n_genes:
+            raise ValueError(
+                f"genes has length {len(genes)} but train_counts has {n_genes} "
+                "columns."
+            )
+        if self.config is None:
+            # Wrapping an already-trained model: only validate the feature space.
+            assert self._model is not None
+            if self._model.n_genes != n_genes:
+                raise ValueError(
+                    f"wrapped model expects {self._model.n_genes} genes but "
+                    f"train_counts has {n_genes}."
+                )
+            return
+
+        import torch
+        from torch.utils.data import DataLoader
+
+        from omvqvae.data.dataset import CountsDataset, collate_minibatch
+        from omvqvae.models.vqvae import OmicsVQVAE
+        from omvqvae.train import TrainConfig, train
+        from omvqvae.utils.tracking import ConsoleTracker
+
+        torch.manual_seed(self.config.seed)
+        dataset = CountsDataset(counts, self.organism)
+        loader: Any = DataLoader(
+            dataset,
+            batch_size=self.batch_size,
+            shuffle=True,
+            collate_fn=collate_minibatch,
+        )
+        model = OmicsVQVAE(n_genes, **self.config.model_kwargs())
+        train_config = TrainConfig(
+            max_epochs=self.config.max_epochs,
+            lr=self.config.lr,
+            grad_clip_norm=self.config.grad_clip_norm,
+            max_steps=self.config.max_steps,
+        )
+        logger.info("Fitting OmvqvaeLatentModel %r (%s).", self.name, n_genes)
+        train(
+            model,
+            loader,
+            config=train_config,
+            tracker=ConsoleTracker(run_name=self.name),
+        )
+        self._model = model
+
+    def embed(self, counts: "CountMatrix") -> np.ndarray:
+        """
+        Embed raw counts into the ``(n_cells, n_latent)`` OQAE latent.
+
+        Returns the continuous pre-quantization latent, or the post-quantization
+        latent when ``use_quantized`` is set.
+
+        Raises
+        ------
+        RuntimeError
+            If the model has not been fit yet.
+        """
+        if self._model is None:
+            raise RuntimeError("OmvqvaeLatentModel.embed called before fit().")
+        from omvqvae.inference import encode
+
+        encoded = encode(self._model, counts)
+        rep = encoded.quantized if self.use_quantized else encoded.latent
+        return np.asarray(rep.detach().cpu().numpy(), dtype=np.float64)
+
+
+class ScviLatentModel:
+    """
+    scVI adapter: train ``scvi.model.SCVI`` and embed via its latent space.
+
+    ``scvi-tools`` is **lazy-imported** inside :meth:`fit` / :meth:`embed`, so it
+    is only required when this baseline is actually used (install the optional
+    ``baselines`` extra). Constructing the object without ``scvi-tools`` is fine;
+    calling :meth:`fit` without it raises a clear, actionable error.
+
+    Parameters
+    ----------
+    name : str, default "scVI"
+        Row label in the comparison table.
+    n_latent : int, default 10
+        scVI latent dimensionality (its default; need not match OQAE's — the
+        latent metrics are dimension-agnostic).
+    max_epochs : int, optional
+        Passed to ``SCVI.train``. Leave ``None`` (default) so scVI uses its own
+        epoch heuristic / early stopping — a realistic budget, not the tiny epoch
+        counts used for OQAE smoke sweeps (see the fairness note in the module
+        docstring).
+    seed : int, default 0
+        Seed passed to ``scvi.settings.seed`` before training for reproducibility.
+    train_kwargs : dict, optional
+        Extra keyword arguments forwarded to ``SCVI.train`` (e.g.
+        ``{"early_stopping": True}``).
+    model_kwargs : dict, optional
+        Extra keyword arguments forwarded to the ``SCVI`` constructor (e.g.
+        ``gene_likelihood``, ``n_layers``).
+
+    Notes
+    -----
+    The adapter trains **unconditionally** (no ``batch_key``) to match v1 OQAE.
+    The protocol's ``fit`` carries no covariate channel, which is exactly why
+    conditioning is out of scope here; document any covariate difference if you
+    change this.
+    """
+
+    def __init__(
+        self,
+        *,
+        name: str = "scVI",
+        n_latent: int = 10,
+        max_epochs: Optional[int] = None,
+        seed: int = 0,
+        train_kwargs: Optional[Dict[str, Any]] = None,
+        model_kwargs: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self.name = name
+        self.n_latent = n_latent
+        self.max_epochs = max_epochs
+        self.seed = seed
+        self.train_kwargs = dict(train_kwargs or {})
+        self.model_kwargs = dict(model_kwargs or {})
+        self._model: Any = None
+        self._genes: Optional[List[str]] = None
+
+    def _build_anndata(  # pragma: no cover - exercised on the live scVI path
+        self, counts: "CountMatrix", genes: Sequence[str]
+    ) -> Any:
+        """Wrap a raw-count matrix + gene ids in an AnnData scVI can consume."""
+        import pandas as pd  # lazy: anndata/pandas only needed on the scVI path
+        from anndata import AnnData
+
+        array = _counts_to_array(counts)
+        if array.shape[1] != len(genes):
+            raise ValueError(
+                f"counts has {array.shape[1]} genes but {len(genes)} gene ids "
+                "were given."
+            )
+        var = pd.DataFrame(index=[str(g) for g in genes])
+        obs = pd.DataFrame(index=[f"cell_{i}" for i in range(array.shape[0])])
+        return AnnData(X=array, obs=obs, var=var)
+
+    def fit(
+        self,
+        train_counts: "CountMatrix",
+        *,
+        genes: Sequence[str],
+        labels: Optional[Sequence[object]] = None,
+    ) -> None:
+        """
+        Train scVI on raw counts ``(n_cells, n_genes)``.
+
+        ``labels`` are ignored (scVI is unsupervised here, matching unconditional
+        OQAE). ``genes`` fixes the feature space; the same ids must be supplied to
+        :meth:`embed`.
+
+        Raises
+        ------
+        ImportError
+            If the optional ``scvi-tools`` dependency is not installed.
+        """
+        try:
+            import scvi
+        except ImportError as exc:
+            raise ImportError(_SCVI_MISSING_MSG) from exc
+
+        # The rest is the live scVI training shell (heavy; needs the extra), so it
+        # is exercised only under the network-marked integration test.
+        scvi.settings.seed = self.seed  # pragma: no cover
+        self._genes = [str(g) for g in genes]  # pragma: no cover
+        adata = self._build_anndata(train_counts, self._genes)  # pragma: no cover
+        scvi.model.SCVI.setup_anndata(adata)  # pragma: no cover
+        self._model = scvi.model.SCVI(  # pragma: no cover
+            adata, n_latent=self.n_latent, **self.model_kwargs
+        )
+        logger.info(  # pragma: no cover
+            "Fitting ScviLatentModel %r (n_latent=%d, max_epochs=%s).",
+            self.name,
+            self.n_latent,
+            self.max_epochs,
+        )
+        self._model.train(  # pragma: no cover
+            max_epochs=self.max_epochs, **self.train_kwargs
+        )
+
+    def embed(self, counts: "CountMatrix") -> np.ndarray:
+        """
+        Embed raw counts into scVI's ``(n_cells, n_latent)`` latent space.
+
+        Raises
+        ------
+        RuntimeError
+            If the model has not been fit yet.
+        """
+        if self._model is None or self._genes is None:
+            raise RuntimeError("ScviLatentModel.embed called before fit().")
+        # Live scVI embedding shell (needs a fitted model + the extra).
+        adata = self._build_anndata(counts, self._genes)  # pragma: no cover
+        latent = self._model.get_latent_representation(adata)  # pragma: no cover
+        return np.asarray(latent, dtype=np.float64)  # pragma: no cover
+
+
+@dataclass
+class LatentModelReport:
+    """
+    One model's row in the latent comparison.
+
+    Attributes
+    ----------
+    name : str
+        The model's display name.
+    n_latent : int
+        Embedding dimensionality returned by ``embed``.
+    separability : float
+        Nearest-centroid separability of the embedding given the labels
+        (:func:`~omvqvae.benchmark.metrics.separability_score`), or ``nan`` when
+        undefined.
+    nmi : float
+        scIB NMI between the labels and a KMeans clustering of the embedding, or
+        ``nan`` when clustering was not requested.
+    ari : float
+        scIB ARI for the same clustering, or ``nan``.
+    cell_type_asw : float
+        Cell-type average silhouette width, rescaled to ``[0, 1]``, or ``nan``.
+    """
+
+    name: str
+    n_latent: int
+    separability: float
+    nmi: float = float("nan")
+    ari: float = float("nan")
+    cell_type_asw: float = float("nan")
+
+
+def compare_latent_models(
+    models: Sequence[LatentModel],
+    eval_counts: "CountMatrix",
+    labels: Sequence[object],
+    *,
+    batch_key: Optional[Sequence[object]] = None,
+    compute_clustering: bool = True,
+) -> List[LatentModelReport]:
+    """
+    Embed shared held-out cells through each model and score the latent spaces.
+
+    Every model must already be **fit**. Each one embeds the *same*
+    ``eval_counts`` and is scored with the *same* latent metrics, so the rows are
+    directly comparable — the whole point of the baseline. Reconstruction NLL is
+    intentionally **not** reported: its units are not comparable across different
+    likelihoods/normalizations (see the module docstring's fairness note).
+
+    Parameters
+    ----------
+    models : Sequence[LatentModel]
+        Fitted models to compare (e.g. an :class:`OmvqvaeLatentModel` and a
+        :class:`ScviLatentModel`).
+    eval_counts : numpy.ndarray or scipy.sparse.spmatrix
+        Shared held-out raw counts ``(n_cells, n_genes)`` embedded by every model.
+    labels : Sequence
+        Per-cell labels (e.g. cell type) used for every latent metric.
+    batch_key : Sequence, optional
+        Per-cell batch annotations for the same cells. Currently reserved for the
+        UMAP batch view (pass it to
+        :func:`~omvqvae.benchmark.viz.plot_latent_umap`'s ``color_by``); it does
+        **not** change the scored metrics. Kept in the signature so the covariate
+        channel is explicit and available to callers.
+    compute_clustering : bool, default True
+        Also compute the scIB NMI / ARI / cell-type-ASW metrics (needs the
+        optional ``benchmark`` extra). When False, only ``separability`` is
+        populated and the rest stay ``nan`` (a dependency-light path).
+
+    Returns
+    -------
+    List[LatentModelReport]
+        One report per model, in input order.
+
+    Raises
+    ------
+    ValueError
+        If an embedding's row count disagrees with ``labels`` / ``eval_counts``.
+    """
+    from omvqvae.benchmark.metrics import separability_score
+
+    n_labels = len(list(labels))
+    if batch_key is not None and len(list(batch_key)) != n_labels:
+        raise ValueError(
+            f"batch_key has length {len(list(batch_key))} but labels has "
+            f"{n_labels}."
+        )
+
+    reports: List[LatentModelReport] = []
+    for model in models:
+        latent = np.asarray(model.embed(eval_counts))
+        if latent.ndim != 2:
+            raise ValueError(
+                f"model {model.name!r} embed returned a {latent.ndim}-D array; "
+                "expected 2-D (n_cells, d)."
+            )
+        if latent.shape[0] != n_labels:
+            raise ValueError(
+                f"model {model.name!r} embedded {latent.shape[0]} cells but "
+                f"labels has {n_labels}."
+            )
+        separability = separability_score(latent, labels)
+        nmi = ari = cell_type_asw = float("nan")
+        if compute_clustering:
+            from omvqvae.benchmark.clustering import clustering_metrics
+
+            cluster = clustering_metrics(latent, labels)
+            nmi, ari, cell_type_asw = (
+                cluster.nmi,
+                cluster.ari,
+                cluster.cell_type_asw,
+            )
+        reports.append(
+            LatentModelReport(
+                name=model.name,
+                n_latent=int(latent.shape[1]),
+                separability=separability,
+                nmi=nmi,
+                ari=ari,
+                cell_type_asw=cell_type_asw,
+            )
+        )
+    return reports
+
+
+def latent_comparison_to_dicts(
+    reports: Sequence[LatentModelReport],
+) -> List[Dict[str, Any]]:
+    """
+    Flatten :class:`LatentModelReport` rows into plain dicts (CSV / DataFrame).
+
+    Parameters
+    ----------
+    reports : Sequence[LatentModelReport]
+        Reports to flatten.
+
+    Returns
+    -------
+    List[Dict[str, Any]]
+        One scalar-valued row per report.
+    """
+    return [
+        {
+            "name": report.name,
+            "n_latent": report.n_latent,
+            "separability": report.separability,
+            "nmi": report.nmi,
+            "ari": report.ari,
+            "cell_type_asw": report.cell_type_asw,
+        }
+        for report in reports
+    ]
+
+
+def format_latent_comparison(reports: Sequence[LatentModelReport]) -> str:
+    """
+    Render latent-model reports as a Markdown comparison table.
+
+    Parameters
+    ----------
+    reports : Sequence[LatentModelReport]
+        Reports to tabulate (one row each).
+
+    Returns
+    -------
+    str
+        A GitHub-flavoured Markdown table; ``"(no models)"`` if empty. The scIB
+        clustering columns appear only when at least one report computed them.
+    """
+    if not reports:
+        return "(no models)"
+
+    show_clustering = any(report.nmi == report.nmi for report in reports)  # not nan
+
+    headers = ["model", "n_latent", "separability"]
+    if show_clustering:
+        headers += ["nmi", "ari", "ct_asw"]
+
+    def _fmt(value: float) -> str:
+        return "nan" if value != value else f"{value:.4g}"
+
+    rows: List[List[str]] = []
+    for report in reports:
+        row = [report.name, str(report.n_latent), _fmt(report.separability)]
+        if show_clustering:
+            row += [_fmt(report.nmi), _fmt(report.ari), _fmt(report.cell_type_asw)]
+        rows.append(row)
+
+    widths = [
+        max(len(headers[col]), *(len(row[col]) for row in rows))
+        for col in range(len(headers))
+    ]
+    sep = "| " + " | ".join("-" * widths[col] for col in range(len(headers))) + " |"
+    header_line = (
+        "| "
+        + " | ".join(headers[col].ljust(widths[col]) for col in range(len(headers)))
+        + " |"
+    )
+    body = [
+        "| "
+        + " | ".join(row[col].ljust(widths[col]) for col in range(len(headers)))
+        + " |"
+        for row in rows
+    ]
+    return "\n".join([header_line, sep, *body])

--- a/src/omvqvae/benchmark/baselines.py
+++ b/src/omvqvae/benchmark/baselines.py
@@ -210,10 +210,11 @@ class OmvqvaeLatentModel:
             )
         if self.config is None:
             # Wrapping an already-trained model: only validate the feature space.
-            assert self._model is not None
-            if self._model.n_genes != n_genes:
+            # __init__ guarantees a model is set whenever config is None.
+            model = self._model
+            if model is not None and model.n_genes != n_genes:
                 raise ValueError(
-                    f"wrapped model expects {self._model.n_genes} genes but "
+                    f"wrapped model expects {model.n_genes} genes but "
                     f"train_counts has {n_genes}."
                 )
             return

--- a/tests/benchmark/test_baselines.py
+++ b/tests/benchmark/test_baselines.py
@@ -1,0 +1,334 @@
+"""Tests for :mod:`omvqvae.benchmark.baselines` (the LatentModel comparison).
+
+The OQAE adapter and the comparison helper are exercised fully offline on tiny
+synthetic data. The scVI adapter needs the optional ``scvi-tools`` dependency, so
+its happy path is guarded with :func:`pytest.importorskip` and marked
+``network``/slow; the missing-dependency error path is tested deterministically
+by hiding ``scvi`` from the import system.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import List, Optional, Sequence
+
+import numpy as np
+import pytest
+
+from omvqvae.benchmark import (
+    BenchmarkConfig,
+    LatentModel,
+    LatentModelReport,
+    OmvqvaeLatentModel,
+    ScviLatentModel,
+    compare_latent_models,
+    format_latent_comparison,
+    latent_comparison_to_dicts,
+)
+
+
+def _program_counts(
+    *, n_cells: int = 48, n_genes: int = 12, n_programs: int = 3, seed: int = 0
+) -> tuple[np.ndarray, List[str], List[str]]:
+    """A tiny raw-count matrix with latent programs, gene ids, and labels."""
+    rng = np.random.default_rng(seed)
+    program_rates = rng.gamma(1.5, 1.0, size=(n_programs, n_genes))
+    programs = rng.integers(0, n_programs, size=n_cells)
+    depths = rng.uniform(0.5, 2.0, size=n_cells)
+    counts = rng.poisson(program_rates[programs] * depths[:, None]).astype(np.float32)
+    genes = [f"ENSG{i:05d}" for i in range(n_genes)]
+    labels = [f"program_{p}" for p in programs]
+    return counts, genes, labels
+
+
+class _FakeLatentModel:
+    """A stub :class:`LatentModel` that returns a fixed embedding."""
+
+    def __init__(self, name: str, embedding: np.ndarray) -> None:
+        self.name = name
+        self._embedding = embedding
+
+    def fit(
+        self,
+        train_counts: np.ndarray,
+        *,
+        genes: Sequence[str],
+        labels: Optional[Sequence[object]] = None,
+    ) -> None:  # pragma: no cover - trivial stub
+        pass
+
+    def embed(self, counts: np.ndarray) -> np.ndarray:
+        return self._embedding
+
+
+# --------------------------------------------------------------------------- #
+# OmvqvaeLatentModel
+# --------------------------------------------------------------------------- #
+
+
+def test_omvqvae_adapter_requires_exactly_one_source() -> None:
+    """Neither / both of config and trained_model is a clear ValueError."""
+    with pytest.raises(ValueError, match="exactly one"):
+        OmvqvaeLatentModel()
+    config = BenchmarkConfig(name="oqae")
+    from omvqvae.models.vqvae import OmicsVQVAE
+
+    model = OmicsVQVAE(4)
+    with pytest.raises(ValueError, match="exactly one"):
+        OmvqvaeLatentModel(config, trained_model=model)
+
+
+def test_omvqvae_adapter_fits_and_embeds() -> None:
+    """A config-driven adapter trains and embeds to (n_cells, n_latent)."""
+    counts, genes, labels = _program_counts()
+    config = BenchmarkConfig(
+        name="oqae-tiny",
+        max_epochs=1,
+        n_latent=8,
+        codebook_size=16,
+        n_codebooks=2,
+        hidden_dims=(16,),
+    )
+    adapter = OmvqvaeLatentModel(config, batch_size=16)
+    assert adapter.name == "oqae-tiny"
+    adapter.fit(counts, genes=genes, labels=labels)
+    latent = adapter.embed(counts)
+    assert latent.shape == (counts.shape[0], 8)
+    assert isinstance(adapter, LatentModel)  # satisfies the protocol
+
+
+def test_omvqvae_adapter_use_quantized_differs() -> None:
+    """The quantized view returns the post-quantization latent."""
+    counts, genes, _ = _program_counts()
+    config = BenchmarkConfig(
+        name="oqae", max_epochs=1, n_latent=8, codebook_size=16, hidden_dims=(16,)
+    )
+    cont = OmvqvaeLatentModel(config, batch_size=16, use_quantized=False)
+    cont.fit(counts, genes=genes)
+    quant = OmvqvaeLatentModel(config, name="oqae-q", batch_size=16, use_quantized=True)
+    quant.fit(counts, genes=genes)
+    assert cont.embed(counts).shape == quant.embed(counts).shape
+    # Continuous and quantized latents are not identical (quantization moves z).
+    assert not np.allclose(cont.embed(counts), quant.embed(counts))
+
+
+def test_omvqvae_adapter_embed_before_fit_raises() -> None:
+    """Embedding before fit is a clear RuntimeError."""
+    adapter = OmvqvaeLatentModel(BenchmarkConfig(name="oqae"))
+    counts, _, _ = _program_counts()
+    with pytest.raises(RuntimeError, match="before fit"):
+        adapter.embed(counts)
+
+
+def test_omvqvae_adapter_gene_length_mismatch_raises() -> None:
+    """A genes/counts width mismatch is caught in fit."""
+    counts, genes, _ = _program_counts()
+    adapter = OmvqvaeLatentModel(BenchmarkConfig(name="oqae"), batch_size=16)
+    with pytest.raises(ValueError, match="genes has length"):
+        adapter.fit(counts, genes=genes[:-1])
+
+
+def test_omvqvae_adapter_rejects_non_2d_counts() -> None:
+    """A non-2-D count array is caught before any training."""
+    adapter = OmvqvaeLatentModel(BenchmarkConfig(name="oqae"), batch_size=16)
+    with pytest.raises(ValueError, match="counts must be 2-D"):
+        adapter.fit(np.zeros((10,), dtype=np.float32), genes=["g0"])
+
+
+def test_omvqvae_adapter_wraps_trained_model() -> None:
+    """A pre-trained model can be wrapped; fit only validates the feature size."""
+    counts, genes, _ = _program_counts()
+    from omvqvae.models.vqvae import OmicsVQVAE
+
+    model = OmicsVQVAE(counts.shape[1], n_latent=8, codebook_size=16)
+    adapter = OmvqvaeLatentModel(trained_model=model, name="pretrained")
+    assert adapter.name == "pretrained"
+    adapter.fit(counts, genes=genes)  # no-op train, just a size check
+    assert adapter.embed(counts).shape == (counts.shape[0], 8)
+
+
+def test_omvqvae_adapter_wrapped_model_size_mismatch_raises() -> None:
+    """A wrapped model whose n_genes disagrees with the data is rejected."""
+    counts, genes, _ = _program_counts()
+    from omvqvae.models.vqvae import OmicsVQVAE
+
+    model = OmicsVQVAE(counts.shape[1] + 1)
+    adapter = OmvqvaeLatentModel(trained_model=model)
+    with pytest.raises(ValueError, match="wrapped model expects"):
+        adapter.fit(counts, genes=genes)
+
+
+# --------------------------------------------------------------------------- #
+# ScviLatentModel — offline error path
+# --------------------------------------------------------------------------- #
+
+
+def test_scvi_adapter_missing_dependency_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without scvi-tools, fit raises a clear, actionable ImportError."""
+    import sys
+
+    # Hiding the module makes `import scvi` fail regardless of what's installed.
+    monkeypatch.setitem(sys.modules, "scvi", None)
+    counts, genes, _ = _program_counts()
+    model = ScviLatentModel()
+    with pytest.raises(ImportError, match="scvi-tools"):
+        model.fit(counts, genes=genes)
+
+
+def test_scvi_adapter_embed_before_fit_raises() -> None:
+    """Embedding before fit is a clear RuntimeError (no scvi needed)."""
+    model = ScviLatentModel()
+    counts, _, _ = _program_counts()
+    with pytest.raises(RuntimeError, match="before fit"):
+        model.embed(counts)
+
+
+# --------------------------------------------------------------------------- #
+# compare_latent_models + reporting
+# --------------------------------------------------------------------------- #
+
+
+def _well_separated_embedding(labels: Sequence[object]) -> np.ndarray:
+    """Build a latent where each label sits on its own axis (separable)."""
+    unique = {value: i for i, value in enumerate(sorted(set(labels)))}
+    d = len(unique)
+    embedding = np.zeros((len(list(labels)), d), dtype=np.float64)
+    for row, value in enumerate(labels):
+        embedding[row, unique[value]] = 5.0
+    return embedding
+
+
+def test_compare_latent_models_one_row_per_model() -> None:
+    """Each model yields exactly one report; separability is populated."""
+    _, _, labels = _program_counts()
+    good = _FakeLatentModel("good", _well_separated_embedding(labels))
+    rng = np.random.default_rng(0)
+    noise = _FakeLatentModel("noise", rng.normal(size=(len(labels), 4)))
+    eval_counts = np.zeros((len(labels), 3), dtype=np.float32)
+
+    reports = compare_latent_models(
+        [good, noise], eval_counts, labels, compute_clustering=False
+    )
+    assert [r.name for r in reports] == ["good", "noise"]
+    assert all(isinstance(r, LatentModelReport) for r in reports)
+    # A perfectly axis-aligned latent separates the labels; noise does not.
+    assert reports[0].separability == pytest.approx(1.0)
+    assert reports[0].separability > reports[1].separability
+    # Clustering columns stay nan when not requested.
+    assert math.isnan(reports[0].nmi)
+
+
+def test_compare_latent_models_batch_key_length_checked() -> None:
+    """A batch_key/labels length mismatch is a clear ValueError."""
+    _, _, labels = _program_counts()
+    model = _FakeLatentModel("m", _well_separated_embedding(labels))
+    eval_counts = np.zeros((len(labels), 3), dtype=np.float32)
+    with pytest.raises(ValueError, match="batch_key has length"):
+        compare_latent_models(
+            [model],
+            eval_counts,
+            labels,
+            batch_key=labels[:-1],
+            compute_clustering=False,
+        )
+
+
+def test_compare_latent_models_row_count_mismatch_raises() -> None:
+    """An embedding with the wrong number of cells is rejected."""
+    _, _, labels = _program_counts()
+    wrong = _FakeLatentModel("wrong", np.zeros((len(labels) - 1, 4)))
+    eval_counts = np.zeros((len(labels), 3), dtype=np.float32)
+    with pytest.raises(ValueError, match="embedded"):
+        compare_latent_models([wrong], eval_counts, labels, compute_clustering=False)
+
+
+def test_compare_latent_models_non_2d_embedding_raises() -> None:
+    """A non-2-D embedding is a clear ValueError."""
+    _, _, labels = _program_counts()
+    bad = _FakeLatentModel("bad", np.zeros((len(labels),)))
+    eval_counts = np.zeros((len(labels), 3), dtype=np.float32)
+    with pytest.raises(ValueError, match="expected 2-D"):
+        compare_latent_models([bad], eval_counts, labels, compute_clustering=False)
+
+
+def test_compare_latent_models_with_clustering() -> None:
+    """With the benchmark extra, clustering columns are populated."""
+    pytest.importorskip("scib_metrics")
+    _, _, labels = _program_counts()
+    good = _FakeLatentModel("good", _well_separated_embedding(labels))
+    eval_counts = np.zeros((len(labels), 3), dtype=np.float32)
+    reports = compare_latent_models(
+        [good], eval_counts, labels, compute_clustering=True
+    )
+    assert not math.isnan(reports[0].nmi)
+    assert reports[0].nmi > 0.9
+
+
+def test_format_and_dicts_empty() -> None:
+    """Empty reports render a placeholder and no rows."""
+    assert format_latent_comparison([]) == "(no models)"
+    assert latent_comparison_to_dicts([]) == []
+
+
+def test_format_latent_comparison_columns() -> None:
+    """The clustering columns show only when some report computed them."""
+    core = [LatentModelReport(name="a", n_latent=8, separability=0.9)]
+    table = format_latent_comparison(core)
+    assert table.startswith("| model")
+    assert "nmi" not in table
+
+    with_clustering = [
+        LatentModelReport(name="a", n_latent=8, separability=0.9, nmi=0.8, ari=0.7)
+    ]
+    table2 = format_latent_comparison(with_clustering)
+    assert "nmi" in table2
+    assert "ct_asw" in table2
+
+
+def test_latent_comparison_to_dicts_roundtrips_fields() -> None:
+    """Flattening preserves every scalar field."""
+    reports = [
+        LatentModelReport(
+            name="m", n_latent=10, separability=0.5, nmi=0.4, ari=0.3, cell_type_asw=0.6
+        )
+    ]
+    rows = latent_comparison_to_dicts(reports)
+    assert rows == [
+        {
+            "name": "m",
+            "n_latent": 10,
+            "separability": 0.5,
+            "nmi": 0.4,
+            "ari": 0.3,
+            "cell_type_asw": 0.6,
+        }
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# scVI integration — needs the optional dependency; skipped by default
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.network
+def test_scvi_adapter_end_to_end() -> None:  # pragma: no cover - needs scvi-tools
+    """ScviLatentModel trains and embeds; compare yields a row per model."""
+    pytest.importorskip("scvi")
+    counts, genes, labels = _program_counts(n_cells=64, n_genes=20)
+    scvi_model = ScviLatentModel(name="scVI", n_latent=5, max_epochs=2)
+    scvi_model.fit(counts, genes=genes)
+    latent = scvi_model.embed(counts)
+    assert latent.shape == (counts.shape[0], 5)
+
+    config = BenchmarkConfig(
+        name="oqae", max_epochs=1, n_latent=8, codebook_size=16, hidden_dims=(16,)
+    )
+    oqae = OmvqvaeLatentModel(config, batch_size=16)
+    oqae.fit(counts, genes=genes)
+
+    reports = compare_latent_models(
+        [oqae, scvi_model], counts, labels, compute_clustering=False
+    )
+    assert [r.name for r in reports] == ["oqae", "scVI"]

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -110,6 +110,34 @@ def test_example_07_latent_quality_core_only() -> None:
     assert fig is None
 
 
+def test_example_compare_scvi_oqae_only() -> None:
+    """The scVI-comparison example runs the OQAE-only path offline."""
+    pytest.importorskip("scib_metrics")
+    pytest.importorskip("umap")
+    module = _load_example("compare_scvi.py")
+    table, oqae_fig, scvi_fig = module.main(use_scvi=False, make_umap=True)
+    assert table.startswith("| model")
+    assert "OQAE" in table
+    assert oqae_fig is not None
+    assert scvi_fig is None
+
+
+def test_example_compare_scvi_imports() -> None:
+    """The scVI-comparison example imports cleanly (scVI path is optional)."""
+    module = _load_example("compare_scvi.py")
+    assert callable(module.main)
+
+
+@pytest.mark.network
+def test_example_compare_scvi_runs() -> None:  # pragma: no cover - needs scvi-tools
+    """Run the full OQAE-vs-scVI comparison end to end (skipped by default)."""
+    pytest.importorskip("scvi")
+    module = _load_example("compare_scvi.py")
+    table, oqae_fig, scvi_fig = module.main(use_scvi=True, make_umap=True)
+    assert "scVI" in table
+    assert oqae_fig is not None and scvi_fig is not None
+
+
 def test_example_03_imports() -> None:
     """The Census example imports cleanly (its ``main`` is network-gated)."""
     module = _load_example("03_census_streaming.py")

--- a/uv.lock
+++ b/uv.lock
@@ -843,6 +843,15 @@ wheels = [
 ]
 
 [[package]]
+name = "docrep"
+version = "0.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/44/8e/250fab1cafeea43f4eb11f1d64cd6313f639965ff62cb0d9da3883655781/docrep-0.3.2.tar.gz", hash = "sha256:ed8a17e201abd829ef8da78a0b6f4d51fb99a4cbd0554adbed3309297f964314", size = 33197, upload-time = "2021-02-16T09:01:50.183Z" }
+
+[[package]]
 name = "docutils"
 version = "0.22.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1069,6 +1078,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/22/4222d7ddf3da30f363edaa98e329c2bce6c65497c9cb2810931c8b2c0fbc/fsspec-2026.6.0-py3-none-any.whl", hash = "sha256:02e0b71817df9b2169dc30a16832045764def1191b43dcff5bb85bdee212d2a1", size = 203949, upload-time = "2026-06-16T01:57:26.358Z" },
 ]
 
+[package.optional-dependencies]
+http = [
+    { name = "aiohttp" },
+]
+
 [[package]]
 name = "furo"
 version = "2025.12.19"
@@ -1138,6 +1152,57 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/08/a5/7b059810934a09fb3ccb657e0843813c1fee1183d3bc2c8041800374aa2c/google_crc32c-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:d511b3153e7011a27ab6ee6bb3a5404a55b994dc1a7322c0b87b29606d9790e2", size = 34878, upload-time = "2025-12-16T00:35:23.142Z" },
     { url = "https://files.pythonhosted.org/packages/52/c5/c171e4d8c44fec1422d801a6d2e5d7ddabd733eeda505c79730ee9607f07/google_crc32c-1.8.0-pp311-pypy311_pp73-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:87fa445064e7db928226b2e6f0d5304ab4cd0339e664a4e9a25029f384d9bb93", size = 28615, upload-time = "2025-12-16T00:40:29.298Z" },
     { url = "https://files.pythonhosted.org/packages/9c/97/7d75fe37a7a6ed171a2cf17117177e7aab7e6e0d115858741b41e9dd4254/google_crc32c-1.8.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f639065ea2042d5c034bf258a9f085eaa7af0cd250667c0635a3118e8f92c69c", size = 28800, upload-time = "2025-12-16T00:40:30.322Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.81.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b0/b5/1ff353970a87eda4c98251e34d2dfd214abd4982dc89119c9252a2a482d2/grpcio-1.81.1.tar.gz", hash = "sha256:6fa10a767143a5e82e8eaab53918af0cd8909a57a27f8cb2288b80a613ac671b", size = 13026582, upload-time = "2026-06-11T12:46:51.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/ea/1c2fa386b718ff493225e61cfc052ef400b4d6ffc54cbe261026432624b5/grpcio-1.81.1-cp311-cp311-linux_armv7l.whl", hash = "sha256:d71d30f2d92f67d944631c523713934fee37292469e182ebcd2c1dd8a64ce53f", size = 6093112, upload-time = "2026-06-11T12:44:52.131Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/18/acf45fa8bd1bc5d7b0c2fd3dc4c209379fbd5bb396b440b68a83342226b7/grpcio-1.81.1-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:b137f4bf3ada9dc44d411478decc6ff09a79ed30b306cd2abaa98408c3588137", size = 12074277, upload-time = "2026-06-11T12:44:55.354Z" },
+    { url = "https://files.pythonhosted.org/packages/48/d7/ee86a60699b7db039f772a2c4a7e4facc7138984ff42c0130933a0063884/grpcio-1.81.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a3acb384427816dd5d470f47e62137b87f74da694faa8a50147012cf40df276a", size = 6640348, upload-time = "2026-06-11T12:44:59.223Z" },
+    { url = "https://files.pythonhosted.org/packages/26/ee/d2de5e47378ffc207d476c230fea3be4d2601edbce9995f4fe45535d4896/grpcio-1.81.1-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:f9a0ebbe45c29b5e5866593c12b78bd9035f0f0f0d4bc8361680cd580d99db49", size = 7331842, upload-time = "2026-06-11T12:45:02.001Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d6/abeda5c2b896a0b341584fe5ac411bbf72e197a9a374c355fb90965e08d2/grpcio-1.81.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0a37165cc80b1a368384b383e63a4c38116a10467ae44c904d2d7468c4470ec2", size = 6842229, upload-time = "2026-06-11T12:45:04.76Z" },
+    { url = "https://files.pythonhosted.org/packages/10/1c/1f0da7d590b4aeee006826ba568d0e419ca14b23e18f901a3da3e9fba613/grpcio-1.81.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6282caffb41ec326d4cb67ca9cf53b739d1b2f975a2acb498c7418e9f7d9a416", size = 7446096, upload-time = "2026-06-11T12:45:07.499Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/81/5c505d508f7c887aa7982d21443a4126597c80d34b0bcf40f9cec576d7f3/grpcio-1.81.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:a35009284d0d3d5c2c9601c164a911b8b4331608d98a9a66d47d97bb2f522b70", size = 8445238, upload-time = "2026-06-11T12:45:10.243Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/b2/524847365122ee509ca17bcc4e092198b700e94af7bfd5bb5e6dd9f3ee66/grpcio-1.81.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1b22c80559854b789a01fd89e8929b3798a156c0829b5282a8939f33ad4115ad", size = 7873989, upload-time = "2026-06-11T12:45:13.102Z" },
+    { url = "https://files.pythonhosted.org/packages/18/fa/07c037c50b006909d1d13a5848774f8aa7b242f70dc03a035c64eea0e6db/grpcio-1.81.1-cp311-cp311-win32.whl", hash = "sha256:428bec0161b48d8cf583c068591bc0016d0d9cfff52462b72b3884861ea768c5", size = 4202223, upload-time = "2026-06-11T12:45:16.166Z" },
+    { url = "https://files.pythonhosted.org/packages/41/ed/6bff15376920942fac6b95b9802752b837437172c9e8fc2d3170546b89cc/grpcio-1.81.1-cp311-cp311-win_amd64.whl", hash = "sha256:30e825f6848d9f18bba350ed6c75c1b02a0b5184474a31db9a32b1fa66fd8c79", size = 4941303, upload-time = "2026-06-11T12:45:18.724Z" },
+    { url = "https://files.pythonhosted.org/packages/85/07/9a979c81738863a738dc23d65177056e71fbb2db817740ed870b33434e7a/grpcio-1.81.1-cp312-cp312-linux_armv7l.whl", hash = "sha256:8b39472beafc0bdcafc4c8c73ad082ebfdb449d566897a61e7acb4fa88089115", size = 6053264, upload-time = "2026-06-11T12:45:21.017Z" },
+    { url = "https://files.pythonhosted.org/packages/75/95/539706ca0d3bd40dbad583dc56fd883da941f37556b629132da5762781b9/grpcio-1.81.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:12b7524c88d4026d3dcb7b0ebe16b6714f3b4af402ddd0f0639ab064a00c87c3", size = 12052560, upload-time = "2026-06-11T12:45:23.652Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/44/f257b7e0bd69c93b06c6cb8ac8d1b901ccb42bedabd83c1a4c77a71f8810/grpcio-1.81.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1e123f9b37edb8375fd74130d1f69c944bbf0a7b06761ae7211154b8759e94d2", size = 6595983, upload-time = "2026-06-11T12:45:26.963Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/f3/19782aa04c960968bef8c5539329d8e3bbc3364e2e46d19eb5e5cc5e43b7/grpcio-1.81.1-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:2c2e2ae6867c2966b8daccc836d54a13218e0007e9a490aeb81dd05be64d22d7", size = 7303455, upload-time = "2026-06-11T12:45:29.707Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/8c/dea020b6d91508cd84463917a63149ec196ee7db505d032ae43fcb3303b9/grpcio-1.81.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:766bc7c9a9c340342f4c864ccbda8e78111e4751f13b895812b9c148fb79e9d0", size = 6809167, upload-time = "2026-06-11T12:45:32.52Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/c7/3030dd940408083bd32cd95d634777a71605ade4887154d93e8a89244946/grpcio-1.81.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b259a04a737cb3496be0901328eb8b7552ed8df4865d8c8f1cf1bffcfc0776a3", size = 7412536, upload-time = "2026-06-11T12:45:35.403Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/dd/1172a9e42b168edcafefad6115346ef619a3fc02158bb170e66ced24bcdd/grpcio-1.81.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:85b10a45b8993d195c4f3ff57025b8d1e11834909ee475c403bfa60cb4caefaf", size = 8408276, upload-time = "2026-06-11T12:45:37.78Z" },
+    { url = "https://files.pythonhosted.org/packages/25/7a/71437c7f3596e5246155c515852795a85a1a8d228190212432b13b97a95d/grpcio-1.81.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8ea1936c26b99999b27479853039a7f34713f56c49375ad52b38535ec93a796c", size = 7849660, upload-time = "2026-06-11T12:45:40.627Z" },
+    { url = "https://files.pythonhosted.org/packages/65/40/7debc0da45d2efebafb82da75644be347497fe4ee250514b8cd3b86ae8bf/grpcio-1.81.1-cp312-cp312-win32.whl", hash = "sha256:a185a04039df6cae8648bc8ab6d6fde7bf94f7188ecf7828e76ac52eef1e41d6", size = 4185819, upload-time = "2026-06-11T12:45:43.027Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b9/8fe3ba5ed462067774ebc1f9c7f26aa7ebcc280ddd476be107153de1339e/grpcio-1.81.1-cp312-cp312-win_amd64.whl", hash = "sha256:3ad74f8bb1a18963914c5452d289422830b39459e8776ebbcd207be1fbfb1d94", size = 4930461, upload-time = "2026-06-11T12:45:45.775Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/42/dcc2e4b600538ef18327c0839d56b7d3c3812337c5d710df5877dbb39b1e/grpcio-1.81.1-cp313-cp313-linux_armv7l.whl", hash = "sha256:b10e1ff4756ed27d5a29d7fc79cfce7ef1ff56ad20025b89bac7cf79e09abbbe", size = 6054466, upload-time = "2026-06-11T12:45:48.43Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/4a/a36e03210183a8a7d4c80c3936acee679f4bd77d5861f369db47b2cc5f05/grpcio-1.81.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:819edbdcb42ab8598b494bcf0222684bbb7a3c772bd1b1f0be7e029a6063c28e", size = 12048795, upload-time = "2026-06-11T12:45:54.011Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/d5/d68e30b29098f63beab6fe501100fe82674ff142b32c672532da86a99b3a/grpcio-1.81.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c5bf2dc311127d91230cc79b92188c082634a06cf66c5234db49a43b910183b0", size = 6599094, upload-time = "2026-06-11T12:45:57.799Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/b3/e837954d279754f638a11cca5dcf6b24a005efb398984cefaf7735945a54/grpcio-1.81.1-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:e8ca6a1fcdb2943c9cbc1804a1baf3acb6071d72a471591678ded84218006e14", size = 7307182, upload-time = "2026-06-11T12:46:00.568Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/1e/b47957057e729adc6cdf519a47f8be2562b7140e280f1418443eb4022192/grpcio-1.81.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e64dd101d380a115cc5a0c7856788adb535f1a4e21fc543775602f8be95180ae", size = 6810962, upload-time = "2026-06-11T12:46:03.312Z" },
+    { url = "https://files.pythonhosted.org/packages/40/26/569868e364e05b19ec8f969da53d230bcd89c962cd198f7c29943155c4d3/grpcio-1.81.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:98a07f9bf591e3a8919797bee1c53f026ba4acd587e5a4404c8e57c9ec36b2a5", size = 7415698, upload-time = "2026-06-11T12:46:06.005Z" },
+    { url = "https://files.pythonhosted.org/packages/36/0c/5440a0582cb5653fc42a6e262eeb22700943313f8076f9dc927491b20a59/grpcio-1.81.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:c261d74b1a945cf895a9d6eccd1685a8e837531beaab782da4d630a8d12deffb", size = 8407779, upload-time = "2026-06-11T12:46:08.84Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/aa/66fe9f39871d766987d869a03ee0842a026f499c7b1e62decb9e78a8088e/grpcio-1.81.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:58ad1131c300d3c9b933802b3cc4dc69d380822935ba50b28703156ea826fbf7", size = 7844521, upload-time = "2026-06-11T12:46:12.171Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/9e/69bb7194861bcd28fb3193261d4f9c3831b4446993f002cf59068943e7ab/grpcio-1.81.1-cp313-cp313-win32.whl", hash = "sha256:78e29211f26da2fdd0e9c6d2b79f489476140cf7029b6a64808ade7ca4156a42", size = 4182786, upload-time = "2026-06-11T12:46:15.192Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/20/3da8bb0d637feccdc3e1e419bb511ce93651ce7d54164f95de22cc0b8b34/grpcio-1.81.1-cp313-cp313-win_amd64.whl", hash = "sha256:edb59506291b647a30884b1d51a599d605f40b20af4a7dc3d33786a47a31de60", size = 4928648, upload-time = "2026-06-11T12:46:17.823Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/58/19414622b1bf6981bc9c05a365bd548e71876c89000083b3af489251e9c0/grpcio-1.81.1-cp314-cp314-linux_armv7l.whl", hash = "sha256:506f48f2f9c29b143fca3dad7b0d518c188b6c9648c75a2ae6e2d9f2c13a060b", size = 6055336, upload-time = "2026-06-11T12:46:20.557Z" },
+    { url = "https://files.pythonhosted.org/packages/32/f1/2ec88adb92b0eba970dd0e0e7dd086341daa3c75eba4f735f9e44bf684b0/grpcio-1.81.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d865db4a6318e1c1bea83292e0ed231090538fc4ca45425b0f0480eb338bbc6e", size = 12056279, upload-time = "2026-06-11T12:46:24.255Z" },
+    { url = "https://files.pythonhosted.org/packages/41/36/e8c5f8c6ec71de73733695ebc809e98b178b534ec6d8eaa31a7ebab4ad4c/grpcio-1.81.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e2aa72e3ce1770317ef534f63d397b55e130725f5149bd36077c3b539019db27", size = 6608225, upload-time = "2026-06-11T12:46:27.601Z" },
+    { url = "https://files.pythonhosted.org/packages/30/22/96fc577a845ab093326d9ab1adb874bd4936c8cf98ac8ed2f3db13a0a2fb/grpcio-1.81.1-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:0490c30c261eded63f3f354979f9dc4502a9fb944cccb60cd9dc85f5a7349854", size = 7306576, upload-time = "2026-06-11T12:46:30.514Z" },
+    { url = "https://files.pythonhosted.org/packages/76/7b/61dab5d5969f28d97fb1009cead1df0a5cd987d3315e1b37f18a4449f8bc/grpcio-1.81.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:410482da976329fe5f4067270401b12cf2bd552ff8020f054ecfaddb5475f9d6", size = 6812165, upload-time = "2026-06-11T12:46:33.699Z" },
+    { url = "https://files.pythonhosted.org/packages/82/78/6e501929d4f5f96462fd82fd9f0f06e5f9612207582b862868d68757b27d/grpcio-1.81.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e3657301562ac3cb8018d30d0d3ebfa39932239f7b5703422057ef14b69949f5", size = 7422962, upload-time = "2026-06-11T12:46:36.511Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/7e/f2157589e66daa78ebb3165942d05a08bdea93b9d11c2bc1e172aef89685/grpcio-1.81.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:24c8e57504c8f45b237e40b99262d181071e5099a07053695b75d97bb53053a0", size = 8408176, upload-time = "2026-06-11T12:46:39.803Z" },
+    { url = "https://files.pythonhosted.org/packages/da/df/c6717fef716e00d235ffb96123baf6dce76d6004f6233fa767c502861460/grpcio-1.81.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b427c19380991a4eaab2f6144b64b99b412043314c6bf4ab544f97bb31ee4190", size = 7846681, upload-time = "2026-06-11T12:46:43.013Z" },
+    { url = "https://files.pythonhosted.org/packages/36/84/3502e9f210a6a5c4438c8aca3f88edd2e04f6a27f3d41b26cf0a0024b096/grpcio-1.81.1-cp314-cp314-win32.whl", hash = "sha256:61233fe8951e5c85dff81c2458b6528624760166946b5b47ea150a589168411f", size = 4264615, upload-time = "2026-06-11T12:46:45.741Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b0/4af731ff7492c68a96e4c71bfd0f4590acde92b31c6fe4894e6465c10ff6/grpcio-1.81.1-cp314-cp314-win_amd64.whl", hash = "sha256:3768a5ff1b2125e6f552e561b6b2dca0e64982d8949689b4df145cf8b98d7821", size = 5070275, upload-time = "2026-06-11T12:46:48.486Z" },
 ]
 
 [[package]]
@@ -1620,6 +1685,39 @@ wheels = [
 ]
 
 [[package]]
+name = "lightning"
+version = "2.6.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fsspec", extra = ["http"] },
+    { name = "lightning-utilities" },
+    { name = "packaging" },
+    { name = "pytorch-lightning" },
+    { name = "pyyaml" },
+    { name = "torch" },
+    { name = "torchmetrics" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/1d/83be8536bec71a0173e762a9a1fd92a24a5ad0d0f74c59550c3c4e6c103b/lightning-2.6.5.tar.gz", hash = "sha256:16a30310ed69afde3748491feb5d13508908effd70390d2bfc203dc0812a4b4a", size = 659201, upload-time = "2026-05-27T14:33:41.806Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c5/fca7144236b6fa3279d0fb3172b32576c5ad8b84a63b9432ad6592d24847/lightning-2.6.5-py3-none-any.whl", hash = "sha256:3702fb7ef4ab51a8c3d4a140f4674514fe72973a9673dfa05e07a078e2767389", size = 848611, upload-time = "2026-05-27T14:33:39.714Z" },
+]
+
+[[package]]
+name = "lightning-utilities"
+version = "0.15.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/45/7fa8f56b17dc0f0a41ec70dd307ecd6787254483549843bef4c30ab5adce/lightning_utilities-0.15.3.tar.gz", hash = "sha256:792ae0204c79f6859721ac7f386c237a33b0ed06ba775009cb894e010a842033", size = 33553, upload-time = "2026-02-22T14:48:53.348Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/f4/ead6e0e37209b07c9baa3e984ccdb0348ca370b77cea3aaea8ddbb097e00/lightning_utilities-0.15.3-py3-none-any.whl", hash = "sha256:6c55f1bee70084a1cbeaa41ada96e4b3a0fea5909e844dd335bd80f5a73c5f91", size = 31906, upload-time = "2026-02-22T14:48:52.488Z" },
+]
+
+[[package]]
 name = "llvmlite"
 version = "0.47.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1645,6 +1743,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/11/03/16090dd6f74ba2b8b922276047f15962fbeea0a75d5601607edb301ba945/llvmlite-0.47.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fa1cbd800edd3b20bc141521f7fd45a6185a5b84109aa6855134e81397ffe72b", size = 56275178, upload-time = "2026-03-31T18:29:42.58Z" },
     { url = "https://files.pythonhosted.org/packages/f5/cb/0abf1dd4c5286a95ffe0c1d8c67aec06b515894a0dd2ac97f5e27b82ab0b/llvmlite-0.47.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f6725179b89f03b17dabe236ff3422cb8291b4c1bf40af152826dfd34e350ae8", size = 55128632, upload-time = "2026-03-31T18:29:46.939Z" },
     { url = "https://files.pythonhosted.org/packages/4f/79/d3bbab197e86e0ff4f9c07122895b66a3e0d024247fcff7f12c473cb36d9/llvmlite-0.47.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6842cf6f707ec4be3d985a385ad03f72b2d724439e118fcbe99b2929964f0453", size = 39153839, upload-time = "2026-03-31T18:29:51.004Z" },
+]
+
+[[package]]
+name = "markdown"
+version = "3.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
 ]
 
 [[package]]
@@ -1816,6 +1923,19 @@ wheels = [
 ]
 
 [[package]]
+name = "ml-collections"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b8/f8/1a9ae6696dbb6bc9c44ddf5c5e84710d77fe9a35a57e8a06722e1836a4a6/ml_collections-1.1.0.tar.gz", hash = "sha256:0ac1ac6511b9f1566863e0bb0afad0c64e906ea278ad3f4d2144a55322671f6f", size = 61356, upload-time = "2025-04-17T08:25:02.247Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/8a/18d4ff2c7bd83f30d6924bd4ad97abf418488c3f908dea228d6f0961ad68/ml_collections-1.1.0-py3-none-any.whl", hash = "sha256:23b6fa4772aac1ae745a96044b925a5746145a70734f087eaca6626e92c05cbc", size = 76707, upload-time = "2025-04-17T08:24:59.038Z" },
+]
+
+[[package]]
 name = "ml-dtypes"
 version = "0.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1872,6 +1992,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
+name = "mudata"
+version = "0.3.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anndata" },
+    { name = "h5py" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "scipy" },
+    { name = "scverse-misc", version = "0.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "scverse-misc", version = "0.0.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "session-info2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d7/18/f6e53e13f8f035725c7e3cce919d2f15e2e962b4e50c17f13d31820d6d6f/mudata-0.3.9.tar.gz", hash = "sha256:27c3fe57baaab32b3d02a19f436b9d441c95fcba5e2191f1d6e8527e1804def1", size = 328501, upload-time = "2026-06-29T09:52:58.643Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/24/71830a5da5e0d6944818c343c8c7c9e638d9fe6df247abaa9fa4e6747901/mudata-0.3.9-py3-none-any.whl", hash = "sha256:cb269a6912baf24a22abf0835c5b961c14ef3c692e5a734fd7132c4783142133", size = 43904, upload-time = "2026-06-29T09:52:57.283Z" },
 ]
 
 [[package]]
@@ -2428,6 +2567,10 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+baselines = [
+    { name = "scvi-tools", version = "1.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "scvi-tools", version = "1.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
 benchmark = [
     { name = "matplotlib" },
     { name = "scib-metrics" },
@@ -2472,6 +2615,7 @@ requires-dist = [
     { name = "rich", specifier = ">=13.0.0" },
     { name = "scib-metrics", marker = "extra == 'benchmark'", specifier = ">=0.5.0" },
     { name = "scipy", specifier = ">=1.9.0" },
+    { name = "scvi-tools", marker = "extra == 'baselines'", specifier = ">=1.1.0" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=7.0.0" },
     { name = "tiledbsoma", specifier = ">=1.12.0" },
     { name = "tiledbsoma-ml", specifier = ">=0.1.0" },
@@ -2482,7 +2626,7 @@ requires-dist = [
     { name = "wandb", specifier = ">=0.21.0" },
     { name = "zarr", specifier = ">=3.0.0" },
 ]
-provides-extras = ["dev", "docs", "benchmark"]
+provides-extras = ["dev", "docs", "benchmark", "baselines"]
 
 [[package]]
 name = "packaging"
@@ -3059,6 +3203,31 @@ wheels = [
 ]
 
 [[package]]
+name = "pyro-api"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/d7/a0812f5c16b0d4464f80a64a44626c5fe200098070be0f32436dbb662775/pyro-api-0.1.2.tar.gz", hash = "sha256:a1b900d9580aa1c2fab3b123ab7ff33413744da7c5f440bd4aadc4d40d14d920", size = 7349, upload-time = "2020-05-15T16:17:41.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/81/957ae78e6398460a7230b0eb9b8f1cb954c5e913e868e48d89324c68cec7/pyro_api-0.1.2-py3-none-any.whl", hash = "sha256:10e0e42e9e4401ce464dab79c870e50dfb4f413d326fa777f3582928ef9caf8f", size = 11981, upload-time = "2020-05-15T16:17:40.492Z" },
+]
+
+[[package]]
+name = "pyro-ppl"
+version = "1.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "opt-einsum" },
+    { name = "pyro-api" },
+    { name = "torch" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/2e/3bcba8688d58f8dc954cef6831c19d52b6017b035d783685d67cd99fa351/pyro_ppl-1.9.1.tar.gz", hash = "sha256:5e1596de276c038a3f77d2580a90d0a97126e0104900444a088eee620bb0d65e", size = 570861, upload-time = "2024-06-02T00:37:39.688Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/37/def183a2a2c8619d92649d62fe0622c4c6c62f60e4151e8fbaa409e7d5ab/pyro_ppl-1.9.1-py3-none-any.whl", hash = "sha256:91fb2c8740d9d3bd548180ac5ecfa04552ed8c471a1ab66870180663b8f09852", size = 755956, upload-time = "2024-06-02T00:37:37.486Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3145,6 +3314,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/52/a0/07907b6ff512674d9b201859f7d212298c44933633c946703a20c25e9d81/pytokens-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:967cf6e3fd4adf7de8fc73cd3043754ae79c36475c1c11d514fc72cf5490094a", size = 306698, upload-time = "2026-01-30T01:03:29.653Z" },
     { url = "https://files.pythonhosted.org/packages/39/2a/cbbf9250020a4a8dd53ba83a46c097b69e5eb49dd14e708f496f548c6612/pytokens-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:584c80c24b078eec1e227079d56dc22ff755e0ba8654d8383b2c549107528918", size = 116287, upload-time = "2026-01-30T01:03:30.912Z" },
     { url = "https://files.pythonhosted.org/packages/c6/78/397db326746f0a342855b81216ae1f0a32965deccfd7c830a2dbc66d2483/pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de", size = 13729, upload-time = "2026-01-30T01:03:45.029Z" },
+]
+
+[[package]]
+name = "pytorch-lightning"
+version = "2.6.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fsspec", extra = ["http"] },
+    { name = "lightning-utilities" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "torch" },
+    { name = "torchmetrics" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/2c/8e73a3929b4c4bd600cafd38a97aaf7242a8cf518fb9f33d27c274ec898f/pytorch_lightning-2.6.5.tar.gz", hash = "sha256:1c32cefa76a1a9c4c5250338272d961d1e48b180e68396849efe128538ddb28e", size = 661673, upload-time = "2026-05-27T14:33:41.961Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/4d/5740c27110b83634d8491c3b5facf0111b3e554c3164f4fb953be9bddaf6/pytorch_lightning-2.6.5-py3-none-any.whl", hash = "sha256:62d9c8549b2278fedc3364f0a5607a56c6063d18635008f8cf3fae8d802b0d76", size = 852407, upload-time = "2026-05-27T14:33:39.856Z" },
 ]
 
 [[package]]
@@ -3425,6 +3613,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/32/e9/c1d43543da87cd27e8e2a74db85cf0b6c5cff2d5f04a86bd584d2fbc2bb0/scanpy-1.11.5-py3-none-any.whl", hash = "sha256:fcd383ddcf7acbf7c0ca232c25ad51b00aec9f8d2f7c8954b8c6ee0962257166", size = 2097836, upload-time = "2025-10-21T08:24:41.741Z" },
 ]
 
+[package.optional-dependencies]
+skmisc = [
+    { name = "scikit-misc", marker = "python_full_version < '3.12'" },
+]
+
 [[package]]
 name = "scanpy"
 version = "1.12.1"
@@ -3462,6 +3655,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/11/18/1ed26bd2231d9bbe9bfe6ba678fdd261d1ec664ab1bca1d30401dc2a9193/scanpy-1.12.1.tar.gz", hash = "sha256:489c6a3763311721089bf0d78e65fd1555606b45f1a9ee97aa85291a12ade67a", size = 14418570, upload-time = "2026-04-10T12:14:00.161Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/e4/b648ac3267001e1582e0b6ffc22b16dada83e206d783115992e83a07773f/scanpy-1.12.1-py3-none-any.whl", hash = "sha256:d482c92d0d7ae7b954a603e16dfcf5f062c511bd5e30e5dfd701c28e1d6b0e78", size = 2148436, upload-time = "2026-04-10T12:13:58.061Z" },
+]
+
+[package.optional-dependencies]
+skmisc = [
+    { name = "scikit-misc", marker = "python_full_version >= '3.12'" },
 ]
 
 [[package]]
@@ -3535,6 +3733,33 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/43/26/b341b8dab5998da6270a3a42c2152c578501354d36f944b5856757035ef8/scikit_learn-1.9.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5bad8f8b9950321b54c965fdcbac6c6c55e79e16646b49977bcf3668d3870a1a", size = 9097190, upload-time = "2026-06-02T11:54:24.454Z" },
     { url = "https://files.pythonhosted.org/packages/fb/de/b650b4d69b84468cfa2e28a3ff7b8103743029e6446ce1a97fe060ef688c/scikit_learn-1.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:78fc56eafd4edb9575d2d8950d1dd152061abb573341a1cb7e099fc40f6c6666", size = 8963204, upload-time = "2026-06-02T11:54:27.428Z" },
     { url = "https://files.pythonhosted.org/packages/ee/f3/ff83d76d7418112e5a61326443cdda87be3545dd8d6599c95b2481a4419e/scikit_learn-1.9.0-cp314-cp314t-win_arm64.whl", hash = "sha256:051075bda8b7aab87b1906ab3d4740a1e1224a19d7b3781a576736edc94e76aa", size = 8222661, upload-time = "2026-06-02T11:54:30.192Z" },
+]
+
+[[package]]
+name = "scikit-misc"
+version = "0.5.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/71/d6d2d1710fb56473817b0520212d33874069952dcb417614f6dd24efb51e/scikit_misc-0.5.2.tar.gz", hash = "sha256:49fa30e4051b341edc7422db66a12c0f59d468729285bfe644d10924dc51be0a", size = 298626, upload-time = "2025-11-03T11:56:30.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/a2/e6d7cf850cd01a40d9d2ba0f78968cb4c67aab2e502384ea2fd02f71b2f1/scikit_misc-0.5.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ffdf5bbfc9d6fea57506d460461b8cc5108b68cf18b7b2f952301ee0581956de", size = 163041, upload-time = "2025-11-03T11:56:12.436Z" },
+    { url = "https://files.pythonhosted.org/packages/60/c5/bf7b2679594ad1747dad9da2882f365dc8916a60ff16b241820c6bb30c04/scikit_misc-0.5.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:07308c764bd78ce14ea34db33c88a07e2ef07250eb8ac6a7faf383246926afa9", size = 151644, upload-time = "2025-11-03T11:56:13.574Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/91/9f5611cacc2a7a09f4251051fca0d55c21054faa8b345ec431711816cd3d/scikit_misc-0.5.2-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2981c3207f02308327845baf8a7d06b829cc632cf605af517cc46bb146915aa9", size = 186981, upload-time = "2025-11-03T11:56:14.564Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/c3/35c9fe02ddda3491df25db7356d849038666bedc3ba6ebdb2217ec954045/scikit_misc-0.5.2-cp311-cp311-win_amd64.whl", hash = "sha256:aee708678a3e6a9567cb47e3d50cb802f1dd8add2c823bb66ff9267096c9e72a", size = 152838, upload-time = "2025-11-03T11:56:15.803Z" },
+    { url = "https://files.pythonhosted.org/packages/56/43/1daca03447aa3bb80e4ca604fac647fc9ce926d928102a2aab9a9426ef18/scikit_misc-0.5.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:36f33c33494bea53196e68ba165a03cc0af19d09f83585adb0dc469d62dff0b7", size = 162933, upload-time = "2025-11-03T11:56:16.738Z" },
+    { url = "https://files.pythonhosted.org/packages/59/48/5a486b3a9cff8cd8abc0bdc21a1a23f9c5b73962ef6e66a502b7636fad08/scikit_misc-0.5.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:efc64474adcec7fc373b13519db19682ae1e75fbed0da044efce1ae232a6bb01", size = 150855, upload-time = "2025-11-03T11:56:17.895Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/7e/f003fd232ec3c3e29ae565e38536dbdef417c76f7c29a67203e05b800f44/scikit_misc-0.5.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cd5a6e06864b07e9fe18c2bac756163e87f26615e5ddaa5f6129fd62535b7cfb", size = 182978, upload-time = "2025-11-03T11:56:19.104Z" },
+    { url = "https://files.pythonhosted.org/packages/46/35/fe7a3074c1453b2b8cd259d1797fc5146d2383603f9ac838c92bc0bca148/scikit_misc-0.5.2-cp312-cp312-win_amd64.whl", hash = "sha256:4e46fd2e8c46625d1e69ea7fa6f4544d73203387e2601f2bbce82ff0a086ada1", size = 150692, upload-time = "2025-11-03T11:56:20.286Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/8f/ded5b0adcac0633653c3ea752d6ef2aa41ffa90e15bf87aaa8b56529a23a/scikit_misc-0.5.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7dfeb264cf8e580e7712e9f5cc9b14b0c159a92a8aeb3e6ac2f9a5dd1b7816f3", size = 161728, upload-time = "2025-11-03T11:56:21.146Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/24/0669b2c82b26405f1a37a69598b77530cce11f8a7e2ab38295b4b03e534f/scikit_misc-0.5.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d9634dac5c60a09b890f44d884d558086345dbbc0bd8a69b641c29177d0be116", size = 149977, upload-time = "2025-11-03T11:56:22.027Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/a3/cbf1039c0e0cb1f2cab13deb5cd3e44ecdba17952d3134e5a5ce97330468/scikit_misc-0.5.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:87bf054fd37fecb437ba057dc0930b2ff727b9a8d6d4d8959f25e2c626b2fd6c", size = 182448, upload-time = "2025-11-03T11:56:22.911Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/e3/40fa5b73733446d88471fd959fcb31f625870e452081c92ff739356bc616/scikit_misc-0.5.2-cp313-cp313-win_amd64.whl", hash = "sha256:986306ae07974101b53fa320d27643694de8fef1a72fa478853dc6cf33854f6d", size = 150074, upload-time = "2025-11-03T11:56:24.499Z" },
+    { url = "https://files.pythonhosted.org/packages/79/8c/b3db8d0372bc44b713357348ecbe3ea4b757ede17efc2890e683864e1aac/scikit_misc-0.5.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d8acca6c314610c41528d74813018c8d756dee8579c449571db61d97168edf64", size = 161798, upload-time = "2025-11-03T11:56:25.301Z" },
+    { url = "https://files.pythonhosted.org/packages/36/44/4f53f914d27b2d8b776aff289d858f79c67a436946f147542cc6a10430a5/scikit_misc-0.5.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:58bb099631a2c97812698b8591d707e31d3f49de2bed46fd6607338982dfd907", size = 150396, upload-time = "2025-11-03T11:56:26.485Z" },
+    { url = "https://files.pythonhosted.org/packages/90/f0/5516a42122635abba704b038ecbec58895ab38be46909759848e37b03828/scikit_misc-0.5.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01d7ce81168675eb2b125d7b0d2fefbd4208c223cc96cb62f8453ce86afbfc9f", size = 182632, upload-time = "2025-11-03T11:56:27.345Z" },
+    { url = "https://files.pythonhosted.org/packages/12/cf/66806ad4a162bbe8a70c397d1c27c316a419c6d13b7429d729ebba362235/scikit_misc-0.5.2-cp314-cp314-win_amd64.whl", hash = "sha256:0f9f868b89c209d79a598d79cebdb7df7effa82526ee809b044ceebeb944bc8f", size = 152889, upload-time = "2025-11-03T11:56:28.702Z" },
 ]
 
 [[package]]
@@ -3640,6 +3865,74 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a3/2e/2fc93b1c9a7dc3c9c44ba8d239a094d21c8cbf3219a57213fc14a7e9bf28/scverse_misc-0.0.8.tar.gz", hash = "sha256:7de6d46e50fc111d366d60b07f165531de97a836a4d702bbbfa2a47a0015fd9e", size = 31621, upload-time = "2026-06-08T12:01:27.683Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/58/3c753c43fed0a96db29b787daa1dacd84acc8f484da5dd5f8627601a4e4a/scverse_misc-0.0.8-py3-none-any.whl", hash = "sha256:dc61dbd9a1bdb1171cda9f73c52567e29159d51ff1a0f24bee2e568ca1f96a4a", size = 13955, upload-time = "2026-06-08T12:01:26.639Z" },
+]
+
+[[package]]
+name = "scvi-tools"
+version = "1.4.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12'",
+]
+dependencies = [
+    { name = "anndata", marker = "python_full_version < '3.12'" },
+    { name = "docrep", marker = "python_full_version < '3.12'" },
+    { name = "lightning", marker = "python_full_version < '3.12'" },
+    { name = "ml-collections", marker = "python_full_version < '3.12'" },
+    { name = "mudata", marker = "python_full_version < '3.12'" },
+    { name = "numba", marker = "python_full_version < '3.12'" },
+    { name = "numpy", marker = "python_full_version < '3.12'" },
+    { name = "pandas", marker = "python_full_version < '3.12'" },
+    { name = "pyro-ppl", marker = "python_full_version < '3.12'" },
+    { name = "rich", marker = "python_full_version < '3.12'" },
+    { name = "scanpy", version = "1.11.5", source = { registry = "https://pypi.org/simple" }, extra = ["skmisc"], marker = "python_full_version < '3.12'" },
+    { name = "scikit-learn", marker = "python_full_version < '3.12'" },
+    { name = "scipy", marker = "python_full_version < '3.12'" },
+    { name = "sparse", marker = "python_full_version < '3.12'" },
+    { name = "tensorboard", marker = "python_full_version < '3.12'" },
+    { name = "torch", marker = "python_full_version < '3.12'" },
+    { name = "torchmetrics", marker = "python_full_version < '3.12'" },
+    { name = "tqdm", marker = "python_full_version < '3.12'" },
+    { name = "xarray", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/c8/54bf569d5061bce2d8aaac491657c2d67ef36b1d37d3b5f6728ad4ce8fd5/scvi_tools-1.4.2.tar.gz", hash = "sha256:c3d2e6e4cd7d41fccdaeead63c72a4d9a1681bb51f2ace107461217a182eb6e2", size = 18310290, upload-time = "2026-02-26T11:47:34.102Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/14/30fa47de2ef9dcc80e4790966410556a066fb5a1eb75fae683f36e11b986/scvi_tools-1.4.2-py3-none-any.whl", hash = "sha256:c453b75b0fa0d222bf0eb3a531607d17f5ea0dbe5b848ab12fd8cc24599884e5", size = 662085, upload-time = "2026-02-26T11:47:31.774Z" },
+]
+
+[[package]]
+name = "scvi-tools"
+version = "1.4.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.15'",
+    "python_full_version >= '3.13' and python_full_version < '3.15'",
+    "python_full_version == '3.12.*'",
+]
+dependencies = [
+    { name = "anndata", marker = "python_full_version >= '3.12'" },
+    { name = "docrep", marker = "python_full_version >= '3.12'" },
+    { name = "lightning", marker = "python_full_version >= '3.12'" },
+    { name = "ml-collections", marker = "python_full_version >= '3.12'" },
+    { name = "mudata", marker = "python_full_version >= '3.12'" },
+    { name = "numba", marker = "python_full_version >= '3.12'" },
+    { name = "numpy", marker = "python_full_version >= '3.12'" },
+    { name = "pandas", marker = "python_full_version >= '3.12'" },
+    { name = "pyro-ppl", marker = "python_full_version >= '3.12'" },
+    { name = "rich", marker = "python_full_version >= '3.12'" },
+    { name = "scanpy", version = "1.12.1", source = { registry = "https://pypi.org/simple" }, extra = ["skmisc"], marker = "python_full_version >= '3.12'" },
+    { name = "scikit-learn", marker = "python_full_version >= '3.12'" },
+    { name = "scipy", marker = "python_full_version >= '3.12'" },
+    { name = "sparse", marker = "python_full_version >= '3.12'" },
+    { name = "tensorboard", marker = "python_full_version >= '3.12'" },
+    { name = "torch", marker = "python_full_version >= '3.12'" },
+    { name = "torchmetrics", marker = "python_full_version >= '3.12'" },
+    { name = "tqdm", marker = "python_full_version >= '3.12'" },
+    { name = "xarray", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/ed/15d35936d8d4ab56516d76939ea60fdd5e8b12c9e115ade1ada2a32f0ca2/scvi_tools-1.4.3.tar.gz", hash = "sha256:79bdbae257f3c40cb5a50a4709ac7f6e498fe9a92da8f54487f14dd94234c445", size = 18402807, upload-time = "2026-05-12T13:30:28.665Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/87/ba97e56c8aa0e07ac68a458df5dae9c696cd1a5ffe2b80c9259bb8f7a5d6/scvi_tools-1.4.3-py3-none-any.whl", hash = "sha256:635a21db462d27731bc3b1e569203cdfe491ca656546da2fbf139b5574a54960", size = 699103, upload-time = "2026-05-12T13:30:20.178Z" },
 ]
 
 [[package]]
@@ -3809,6 +4102,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
+]
+
+[[package]]
+name = "sparse"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numba" },
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/64/46da3957f8f9af03179eca946d786c56f22b9458cedf472850e02948a8c1/sparse-0.18.0.tar.gz", hash = "sha256:57f92661eb0ec0c764b450c72f3c0d869ea7f32e5e4ca0a335f9d6a7d79bbff4", size = 791987, upload-time = "2026-02-19T06:17:55.376Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/a9/804ac7423f5dda316d3a982f3ab071c971fb877f8961dad9f6a97d12d2ee/sparse-0.18.0-py2.py3-none-any.whl", hash = "sha256:6f4a127d5aae88eca41ea8106bbd5a7830f83d068b37291df597a43511212069", size = 151931, upload-time = "2026-02-19T06:17:53.11Z" },
 ]
 
 [[package]]
@@ -3991,6 +4297,36 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
+name = "tensorboard"
+version = "2.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py" },
+    { name = "grpcio" },
+    { name = "markdown" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "protobuf" },
+    { name = "setuptools" },
+    { name = "tensorboard-data-server" },
+    { name = "werkzeug" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/4b/cd2eec9642781a8f5b2fb9994e3933a7b259ab18e9d49aeede9b5acf6311/tensorboard-2.21.0-py3-none-any.whl", hash = "sha256:7279316dcb6bd5bc391d623dea841531299cde1887310e8133bc34a996d32255", size = 5516204, upload-time = "2026-06-29T20:48:04.472Z" },
+]
+
+[[package]]
+name = "tensorboard-data-server"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/13/e503968fefabd4c6b2650af21e110aa8466fe21432cd7c43a84577a89438/tensorboard_data_server-0.7.2-py3-none-any.whl", hash = "sha256:7e0610d205889588983836ec05dc098e80f97b7e7bbff7e994ebb78f578d0ddb", size = 2356, upload-time = "2023-10-23T21:23:32.16Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/85/dabeaf902892922777492e1d253bb7e1264cadce3cea932f7ff599e53fea/tensorboard_data_server-0.7.2-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:9fe5d24221b29625dbc7328b0436ca7fc1c23de4acf4d272f1180856e32f9f60", size = 4823598, upload-time = "2023-10-23T21:23:33.714Z" },
+    { url = "https://files.pythonhosted.org/packages/73/c6/825dab04195756cf8ff2e12698f22513b3db2f64925bdd41671bfb33aaa5/tensorboard_data_server-0.7.2-py3-none-manylinux_2_31_x86_64.whl", hash = "sha256:ef687163c24185ae9754ed5650eb5bc4d84ff257aabdc33f0cc6f74d8ba54530", size = 6590363, upload-time = "2023-10-23T21:23:35.583Z" },
 ]
 
 [[package]]
@@ -4197,6 +4533,21 @@ wheels = [
 ]
 
 [[package]]
+name = "torchmetrics"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lightning-utilities" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "torch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/34/39b8b749333db56c0585d7a11fa62a283c087bb1dfc897d69fb8cedbefb1/torchmetrics-1.9.0.tar.gz", hash = "sha256:a488609948600df52d3db4fcdab02e62aab2a85ef34da67037dc3e65b8512faa", size = 581765, upload-time = "2026-03-09T17:41:22.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/a2/c7f6ebf546f8f644edf0f999aa98ece106986a77a7b922316bf6414ff825/torchmetrics-1.9.0-py3-none-any.whl", hash = "sha256:bfdcbff3dd1d96b3374bb2496eb39f23c4b28b8a845b6a18c313688e0d2d9ca1", size = 983384, upload-time = "2026-03-09T17:41:19.756Z" },
+]
+
+[[package]]
 name = "tqdm"
 version = "4.68.3"
 source = { registry = "https://pypi.org/simple" }
@@ -4361,6 +4712,18 @@ wheels = [
 ]
 
 [[package]]
+name = "werkzeug"
+version = "3.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44", size = 875852, upload-time = "2026-04-02T18:49:14.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50", size = 226459, upload-time = "2026-04-02T18:49:12.72Z" },
+]
+
+[[package]]
 name = "wrapt"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4433,6 +4796,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ab/31/2a7dc5f6abb2fca0b6e1610e120419f603650aceb4f1d3ac4cae0354e162/wrapt-2.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:fd0135d34387f5fd087d9be368ea77ea89cf2451dc1cd1c622d35021bcb3ab50", size = 83835, upload-time = "2026-05-22T14:49:21.634Z" },
     { url = "https://files.pythonhosted.org/packages/9f/c0/782b86e28d1ceebeb74cccea12d2cd3d2ba0bd68e3dec20b1bc5873f6127/wrapt-2.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:f70db64e8266d7c45d3b735f2e08eeb434b5e03da9a479ae42b2e2e486a21a00", size = 80722, upload-time = "2026-05-22T14:49:23.59Z" },
     { url = "https://files.pythonhosted.org/packages/53/46/29ac9daf11a86c22a8c38cd9236c62928ccae83f7ceb06bd3b0467cf9d05/wrapt-2.2.1-py3-none-any.whl", hash = "sha256:3aafea2975caef8ca49400640dde02cc7426e798f24870ed01f490bc3cffd32f", size = 61000, upload-time = "2026-05-22T14:49:41.593Z" },
+]
+
+[[package]]
+name = "xarray"
+version = "2026.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pandas" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4b/a6/6fe936a798a3a38a79c7422d1a31afd2e9a14690fcb0ccff96bc01f04bf2/xarray-2026.4.0.tar.gz", hash = "sha256:c4ac9a01a945d90d5b1628e2af045099a9d4943536d4f2ee3ae963c3b222d15b", size = 3132311, upload-time = "2026-04-13T19:45:36.688Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/83/6d810a8a9ebc9c307989b418840c20e46907c74d707beb67ab566773e6fc/xarray-2026.4.0-py3-none-any.whl", hash = "sha256:d43751d9fb4a90f9249c30431684f00c41bc874f1edccd862631a40cbc0edf08", size = 1414326, upload-time = "2026-04-13T19:45:34.659Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #37.

## What & why

OQAE's benchmark ranks OQAE configs but a bare separability of ~0.70 is
uninterpretable on its own — it's entirely dataset/metric dependent. Running a
well-tested external VAE (**scVI**) on the **same cells, same genes, same
metric** turns that number into a claim: `0.70 vs 0.72` = essentially matched;
`0.70 vs 0.85` = a real gap to close.

scVI doesn't fit `OmicsVQVAE`/`BenchmarkConfig`, and we don't force it to. Every
metric that transfers needs only a **latent embedding**, so this adds a thin
`LatentModel` protocol and adapts both models to it.

## Changes

- **`src/omvqvae/benchmark/baselines.py`**
  - `LatentModel` `Protocol` — `name` + `fit(train_counts, *, genes, labels=None)`
    + `embed(counts) -> (n_cells, d)`.
  - `OmvqvaeLatentModel` — config-driven training of an `OmicsVQVAE` (or wrap an
    already-trained model); `embed` returns the continuous latent, or the
    post-quantization `.quantized` view opt-in.
  - `ScviLatentModel` — wraps `scvi.model.SCVI`, **lazy-imported** with a clear
    "install the `baselines` extra" `ImportError`; trains **unconditionally**
    (no `batch_key`) to match v1 OQAE.
  - `compare_latent_models(models, eval_counts, labels, batch_key=None)` — embeds
    shared held-out cells through each fitted model and scores them with the
    **same** shared metrics (`separability_score` + optional scIB
    `clustering_metrics`), returning a one-row-per-model table via
    `format_latent_comparison` / `latent_comparison_to_dicts`.
- **Fairness (enforced in docstrings):** no cross-model reconstruction NLL
  (incomparable units); same gene panel/cells/split; scVI gets a realistic
  budget (`max_epochs=None` → its own early stopping).
- **Packaging:** new optional `baselines` extra (`scvi-tools>=1.1.0`), kept out
  of `dev` and the offline default suite; `uv.lock` refreshed; `scvi.*` mypy
  ignore-missing override.
- **`examples/compare_scvi.py`** mirrors the config-sweep examples — trains OQAE
  + scVI on the same data, prints the comparison, saves a UMAP per model. The
  OQAE-only path runs offline; the full scVI path is `network`-gated.
- Docs (`api.rst`, `examples/README.md`) and `docs/STATUS.md` updated.

## Tests
- Offline: OQAE adapter (fit/embed, wrap-a-trained-model, quantized view, every
  guard), the scVI **missing-dependency** error (deterministic — hides `scvi`
  from `sys.modules`), and `compare_latent_models` + reporting.
- `pytest.importorskip("scvi")` + `@pytest.mark.network` integration test asserts
  `ScviLatentModel.embed` returns `(n_cells, d)` and `compare_latent_models`
  yields a row per model. The scVI training/embedding shell is `# pragma: no cover`.

## Acceptance
- `make ci` green (274 passed, ~99.6%); `make docs` clean.
- `scvi-tools` only in the `baselines` extra; `uv.lock` refreshed; offline default
  suite unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)